### PR TITLE
[3] Automatically generate hpp/cpp for blockchain tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ elseif(UBSAN)
     include(cmake/ubsan.cmake)
 endif()
 
+add_subdirectory(tools)
+
 if(TESTING)
     enable_testing()
     add_subdirectory(test)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -79,3 +79,34 @@ function(add_cache_flag var_name flag)
         set("${var_name}" "${flag} ${${var_name}}" CACHE STRING "" FORCE)
     endif()
 endfunction()
+
+# reads file contents and creates a single cpp in ${CMAKE_CURRENT_BINARY_DIR}/${varname}.cpp
+## varname[in] - variable name, as well as file name
+## infile[in] - input file path
+## out[out] - returns full path to generated file
+##
+####################################################
+## add this to hpp, and include this hpp to access
+## the variable.
+####################################################
+## #pragma once
+## namespace generated {
+##   extern const char ${varname}[];
+## }
+##
+function(gencpp varname infile out)
+    get_filename_component(_absin ${infile} REALPATH)
+    set(path ${varname}.cpp)
+    set(${out} ${path} PARENT_SCOPE)
+
+    add_custom_command(
+            OUTPUT ${path}
+            COMMAND filetoheader
+            ARGS
+            ${varname}
+            ${_absin}
+            ${path}
+            DEPENDS filetoheader
+            COMMENT "Generating ${varname}.cpp..."
+    )
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(${CMAKE_CURRENT_LIST_DIR})
+include_directories(${CMAKE_BINARY_DIR}/include)
 
 add_subdirectory(blockchain)
 add_subdirectory(third_party)

--- a/test/blockchain/CMakeLists.txt
+++ b/test/blockchain/CMakeLists.txt
@@ -1,2 +1,20 @@
-addtest(blockchain_test chain_test.cpp btc_blockchain_test.cpp blockchain_test.cpp)
+gencpp(
+        btc_blockheaders_mainnet_0_10000
+        ./btc_blockheaders_mainnet_0_10000
+        outcpp1
+)
+gencpp(
+        btc_blockheaders_mainnet_30000_40000
+        ./btc_blockheaders_mainnet_30000_40000
+        outcpp2
+)
+
+addtest(blockchain_test
+        chain_test.cpp
+        btc_blockchain_test.cpp
+        blockchain_test.cpp
+        # generated cpps
+        ${outcpp1}
+        ${outcpp2}
+        )
 target_link_libraries(blockchain_test vbkutils)

--- a/test/blockchain/block_headers.hpp
+++ b/test/blockchain/block_headers.hpp
@@ -1,0 +1,11 @@
+#ifndef ALT_INTEGRATION_TEST_BLOCKCHAIN_BLOCK_HEADERS_HPP_
+#define ALT_INTEGRATION_TEST_BLOCKCHAIN_BLOCK_HEADERS_HPP_
+
+namespace generated {
+
+extern const char btc_blockheaders_mainnet_0_10000[];
+extern const char btc_blockheaders_mainnet_30000_40000[];
+
+}
+
+#endif  // ALT_INTEGRATION_TEST_BLOCKCHAIN_BLOCK_HEADERS_HPP_

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(filetoheader EXCLUDE_FROM_ALL filetoheader.cpp)

--- a/tools/filetoheader.cpp
+++ b/tools/filetoheader.cpp
@@ -11,9 +11,9 @@ void write(InStream& in, OutStream& out, const std::string& var) {
   std::string line;
   while (std::getline(in, line)) {
     for (char c : line) {
-      out << (int)c << ", ";
+      out << reinterpret_cast<int>(c) << ", ";
     }
-    out << (int)'\n' << ", " << std::endl;
+    out << static_cast<int>('\n') << ", " << std::endl;
   }
   out << 0 << std::endl;     // null terminator
   out << "};" << std::endl;  // end of array

--- a/tools/filetoheader.cpp
+++ b/tools/filetoheader.cpp
@@ -11,7 +11,7 @@ void write(InStream& in, OutStream& out, const std::string& var) {
   std::string line;
   while (std::getline(in, line)) {
     for (char c : line) {
-      out << reinterpret_cast<int>(c) << ", ";
+      out << static_cast<int>(c) << ", ";
     }
     out << static_cast<int>('\n') << ", " << std::endl;
   }

--- a/tools/filetoheader.cpp
+++ b/tools/filetoheader.cpp
@@ -20,6 +20,7 @@ void write(InStream& in, OutStream& out, const std::string& var) {
   out << "};" << std::endl;  // end of namespace
 }
 
+// NOLINTNEXTLINE
 int main(int argc, char** argv) {
   if (argc != 4) {
     std::cout << R"(  Usage:
@@ -28,9 +29,9 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::string var = argv[1];
-  std::string in = argv[2];
-  std::string out = argv[3];
+  std::string var = argv[1]; // NOLINT
+  std::string in = argv[2];  // NOLINT
+  std::string out = argv[3]; // NOLINT
   std::fstream fout(out, std::fstream::out);
   std::fstream fin(in, std::fstream::in);
 

--- a/tools/filetoheader.cpp
+++ b/tools/filetoheader.cpp
@@ -1,0 +1,40 @@
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+template <typename InStream, typename OutStream>
+void write(InStream& in, OutStream& out, const std::string& var) {
+  out << "namespace generated {" << std::endl;
+  out << "extern const char " << var << "[] = {" << std::endl;
+  std::string line;
+  while (std::getline(in, line)) {
+    for (char c : line) {
+      out << (int)c << ", ";
+    }
+    out << (int)'\n' << ", " << std::endl;
+  }
+  out << 0 << std::endl;     // null terminator
+  out << "};" << std::endl;  // end of array
+  out << "};" << std::endl;  // end of namespace
+}
+
+int main(int argc, char** argv) {
+  if (argc != 4) {
+    std::cout << R"(  Usage:
+   stringtobytes variable_name infile outfile
+)";
+    return 1;
+  }
+
+  std::string var = argv[1];
+  std::string in = argv[2];
+  std::string out = argv[3];
+  std::fstream fout(out, std::fstream::out);
+  std::fstream fin(in, std::fstream::in);
+
+  write(fin, fout, var);
+
+  return 0;
+}


### PR DESCRIPTION
The problem: tests should NOT depend on test files in RUNTIME, because this leads to problems with paths, and file existence.
Solution: add compile time parsing of files with headers.

This solution is optimal, but it seems that on windows it will not build... Any ideas how to solve?