### PR TITLE
Optimize addPayloads

### DIFF
--- a/include/veriblock/blockchain/alt_block_tree.hpp
+++ b/include/veriblock/blockchain/alt_block_tree.hpp
@@ -13,8 +13,8 @@
 #include "veriblock/blockchain/pop/vbk_block_tree.hpp"
 #include "veriblock/entities/altblock.hpp"
 #include "veriblock/entities/payloads.hpp"
-#include "veriblock/validation_state.hpp"
 #include "veriblock/rewards/poprewards.hpp"
+#include "veriblock/validation_state.hpp"
 
 namespace altintegration {
 
@@ -69,9 +69,13 @@ struct AltTree {
 
   //! add payloads to any of existing blocks in block tree.
   //! may return false, if payloads statelessly, or statefully invalid.
+  //! @param atomic If false, may leave tree in indeterminate state for invalid
+  //! payloads. If true, guarantees that tree will remain unchanged for invalid
+  //! payloads.
   bool addPayloads(const AltBlock& containingBlock,
                    const std::vector<payloads_t>& payloads,
-                   ValidationState& state);
+                   ValidationState& state,
+                   bool atomic = true);
 
   //! removes given payloads from given block index.
   //! remove ALL payloads from a block, when it has to be removed
@@ -85,7 +89,8 @@ struct AltTree {
    * Calculate payouts for the given block
    * @return map with reward recipient as a key and reward amount as a value
    */
-  std::map<std::vector<uint8_t>, int64_t> getPopPayout(const AltBlock::hash_t& block);
+  std::map<std::vector<uint8_t>, int64_t> getPopPayout(
+      const AltBlock::hash_t& block);
 
   /**
    * Determine the best chain of the AltBlocks in accordance with the VeriBlock
@@ -110,8 +115,9 @@ struct AltTree {
 
   const block_index_t& getAllBlocks() const { return block_index_; }
 
-  bool operator == (const AltTree& o) const {
-    return chainTips_ == o.chainTips_ && block_index_ == o.block_index_ && cmp_ == o.cmp_;
+  bool operator==(const AltTree& o) const {
+    return chainTips_ == o.chainTips_ && block_index_ == o.block_index_ &&
+           cmp_ == o.cmp_;
   }
 
  protected:
@@ -130,6 +136,11 @@ struct AltTree {
   index_t* touchBlockIndex(const hash_t& blockHash);
 
   void addToChains(index_t* block_index);
+
+  bool addPayloads(PopForkComparator& cmp,
+                   const AltBlock& containingBlock,
+                   const std::vector<payloads_t>& payloads,
+                   ValidationState& state);
 };
 
 template <>

--- a/include/veriblock/blockchain/pop/vbk_block_tree.hpp
+++ b/include/veriblock/blockchain/pop/vbk_block_tree.hpp
@@ -54,7 +54,8 @@ struct VbkBlockTree : public BlockTree<VbkBlock, VbkChainParams> {
 
   bool addPayloads(const block_t& block,
                    const std::vector<payloads_t>& payloads,
-                   ValidationState& state);
+                   ValidationState& state,
+                   bool atomic = true);
 
   void removePayloads(const block_t& block,
                       const std::vector<payloads_t>& payloads);
@@ -69,6 +70,11 @@ struct VbkBlockTree : public BlockTree<VbkBlock, VbkChainParams> {
   void determineBestChain(Chain<index_t>& currentBest,
                           index_t& indexNew,
                           bool isBootstrap = false) override;
+
+  bool addPayloads(PopForkComparator& cmp,
+                   const block_t& block,
+                   const std::vector<payloads_t>& payloads,
+                   ValidationState& state);
 
   PopForkComparator cmp_;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+link_libraries(${LIB_NAME})
 include_directories(${CMAKE_CURRENT_LIST_DIR})
 include_directories(${CMAKE_BINARY_DIR}/include)
 
@@ -10,16 +11,12 @@ add_subdirectory(third_party)
 add_subdirectory(entities)
 
 addtest(vblake_test vblake_test.cpp)
-target_link_libraries(vblake_test ${LIB_NAME})
 
 addtest(streamutils_test streamutils_test.cpp)
-target_link_libraries(streamutils_test ${LIB_NAME})
 
 addtest(base58_test base58_test.cpp)
-target_link_libraries(base58_test ${LIB_NAME})
 
 addtest(base59_test base59_test.cpp)
-target_link_libraries(base59_test ${LIB_NAME})
 
 
 gencpp(
@@ -36,22 +33,15 @@ addtest(config_test config_test.cpp
         ${btc_headers}
         ${vbk_headers}
         )
-target_link_libraries(config_test ${LIB_NAME})
 
 addtest(stateless_validation_test stateless_validation_test.cpp)
-target_link_libraries(stateless_validation_test ${LIB_NAME})
 
 addtest(arith_uint256_test arith_uint256_test.cpp)
-target_link_libraries(arith_uint256_test ${LIB_NAME})
 
 addtest(signutil_test signutil_test.cpp)
-target_link_libraries(signutil_test ${LIB_NAME})
 
 addtest(keystone_util_test keystone_util_test.cpp)
-target_link_libraries(keystone_util_test ${LIB_NAME})
 
 addtest(validationstate_test validationstate_test.cpp)
-target_link_libraries(validationstate_test ${LIB_NAME})
 
 addtest(alt-util_test alt-util_test.cpp)
-target_link_libraries(alt-util_test ${LIB_NAME})

--- a/test/blockchain/CMakeLists.txt
+++ b/test/blockchain/CMakeLists.txt
@@ -36,9 +36,6 @@ addtest(btc_blockchain_test
         ${btc_gen_1}
         ${btc_gen_2}
         )
-target_link_libraries(btc_blockchain_test
-        ${LIB_NAME}
-        )
 set_target_properties(btc_blockchain_test PROPERTIES
         COST 10000  # 10 sec
         )
@@ -50,9 +47,6 @@ addtest(vbk_blockchain_test
         ${vbk_gen_1}
         ${vbk_gen_2}
         )
-target_link_libraries(vbk_blockchain_test
-        ${LIB_NAME}
-        )
 set_target_properties(vbk_blockchain_test PROPERTIES
         COST 300000  # many sec
         )
@@ -60,9 +54,6 @@ set_target_properties(vbk_blockchain_test PROPERTIES
 addtest(vbk_getblockproof_test
         vbk_getblockproof_test.cpp
         ${vbk_blocks_gen_1}
-        )
-target_link_libraries(vbk_getblockproof_test
-        ${LIB_NAME}
         )
 set_target_properties(vbk_getblockproof_test PROPERTIES
         COST 30000 # 30 sec
@@ -72,17 +63,11 @@ addtest(blockchain_test
         chain_test.cpp
         blockchain_test.cpp
         )
-target_link_libraries(blockchain_test
-        ${LIB_NAME}
-        )
 set_target_properties(blockchain_test PROPERTIES
         COST 10000  # 10 sec
         )
 
 
 addtest(chainparams_test chainparams_test.cpp)
-target_link_libraries(chainparams_test ${LIB_NAME})
 
-addtest(alt_blockchain_test
-        alt_blockchain_test.cpp)
-target_link_libraries(alt_blockchain_test ${LIB_NAME})
+addtest(alt_blockchain_test alt_blockchain_test.cpp)

--- a/test/blockchain/pop/CMakeLists.txt
+++ b/test/blockchain/pop/CMakeLists.txt
@@ -3,10 +3,7 @@ addtest(pop_utils_test
         pop_vbk_block_tree_test.cpp
         pop_state_machine_test.cpp
         )
-target_link_libraries(pop_utils_test ${LIB_NAME})
 
 addtest(pop_vbk_fork_resolution_test pop_vbk_fork_resolution_test.cpp)
-target_link_libraries(pop_vbk_fork_resolution_test ${LIB_NAME})
 
 addtest(pop_context_test pop_context_test.cpp)
-target_link_libraries(pop_context_test ${LIB_NAME})

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -1,9 +1,7 @@
 add_subdirectory(scenario_0)
 
-addtest(e2e_test scenario_1.cpp
-                 scenario_2.cpp
-                 scenario_3.cpp
-                 scenario_4.cpp
-                 scenario_5.cpp
-)
-target_link_libraries(e2e_test ${LIB_NAME})
+addtest(scenario_1 scenario_1.cpp)
+addtest(scenario_2 scenario_2.cpp)
+addtest(scenario_3 scenario_3.cpp)
+addtest(scenario_4 scenario_4.cpp)
+addtest(scenario_5 scenario_5.cpp)

--- a/test/e2e/scenario_0/CMakeLists.txt
+++ b/test/e2e/scenario_0/CMakeLists.txt
@@ -10,4 +10,3 @@ addtest(scenario_0
         ${btcblocks}
         ${vbkblocks}
         )
-target_link_libraries(scenario_0 ${LIB_NAME})

--- a/test/e2e/scenario_3.cpp
+++ b/test/e2e/scenario_3.cpp
@@ -63,13 +63,13 @@ TEST_F(Scenario3, scenario_3) {
   // vbkTip1 heigher than vbkTip2
   ASSERT_GT(vbkTip1->height, vbkTip2->height);
   // but active chain on the vbkTip2 because this chain has endorsements
-  ASSERT_EQ(vbkTip2->getHash(), popminer.vbk().getBestChain().tip()->getHash());
+  ASSERT_EQ(*vbkTip2, *popminer.vbk().getBestChain().tip());
 
   vbkTip1 = popminer.mineVbkBlocks(*vbkTip1, {popTx1, popTx3});
 
   // now we switch active chain to the better endorsements
   ASSERT_GT(vbkTip1->height, vbkTip2->height);
-  ASSERT_EQ(vbkTip1->getHash(), popminer.vbk().getBestChain().tip()->getHash());
+  ASSERT_EQ(*vbkTip1, *popminer.vbk().getBestChain().tip());
 
   auto vtbs1 = popminer.vbkPayloads[vbkTip1->getHash()];
   auto vtbs2 = popminer.vbkPayloads[vbkTip2->getHash()];
@@ -104,8 +104,7 @@ TEST_F(Scenario3, scenario_3) {
       tx, containingBlock, endorsedBlock, vbkparam.getGenesisBlock().getHash());
 
   // new tip is the next block after vbkTip1
-  ASSERT_EQ(popminer.vbk().getBestChain().tip()->pprev->getHash(),
-            vbkTip1->getHash());
+  ASSERT_EQ(*popminer.vbk().getBestChain().tip()->pprev, *vbkTip1);
   vbkTip1 = popminer.vbk().getBestChain().tip();
 
   // store vtbs in different altPayloads
@@ -114,19 +113,16 @@ TEST_F(Scenario3, scenario_3) {
   EXPECT_TRUE(alttree.addPayloads(containingBlock, {altPayloads1}, state));
   EXPECT_TRUE(state.IsValid());
 
-  EXPECT_EQ(alttree.vbk().getBestChain().tip()->getHash(), vbkTip1->getHash());
+  EXPECT_EQ(*alttree.vbk().getBestChain().tip(), *vbkTip1);
 
   auto* containingVbkBlock =
       alttree.vbk().getBlockIndex(vtbs1[1].containingBlock.getHash());
 
   // check endorsements
-  EXPECT_TRUE(containingVbkBlock->containingEndorsements.find(
-                  BtcEndorsement::fromContainer(vtbs1[0]).id) ==
-              containingVbkBlock->containingEndorsements.end());
-
-  EXPECT_TRUE(containingVbkBlock->containingEndorsements.find(
-                  BtcEndorsement::fromContainer(vtbs1[1]).id) !=
-              containingVbkBlock->containingEndorsements.end());
+  EXPECT_FALSE(containingVbkBlock->containingEndorsements.count(
+      BtcEndorsement::getId(vtbs1[0])));
+  EXPECT_TRUE(containingVbkBlock->containingEndorsements.count(
+      BtcEndorsement::getId(vtbs1[1])));
 
   // Step 3
   containingBlock = generateNextBlock(*chain.rbegin());
@@ -154,8 +150,7 @@ TEST_F(Scenario3, scenario_3) {
       tx, containingBlock, endorsedBlock, vbkparam.getGenesisBlock().getHash());
 
   // new tip is the next block after vbkTip1
-  ASSERT_EQ(popminer.vbk().getBestChain().tip()->pprev->getHash(),
-            vbkTip1->getHash());
+  ASSERT_EQ(*popminer.vbk().getBestChain().tip()->pprev, *vbkTip1);
   vbkTip1 = popminer.vbk().getBestChain().tip();
 
   // store vtbs in different altPayloads
@@ -165,13 +160,10 @@ TEST_F(Scenario3, scenario_3) {
   EXPECT_TRUE(state.IsValid());
 
   // check endorsements
-  EXPECT_TRUE(containingVbkBlock->containingEndorsements.find(
-                  BtcEndorsement::fromContainer(vtbs1[0]).id) !=
-              containingVbkBlock->containingEndorsements.end());
+  EXPECT_TRUE(containingVbkBlock->containingEndorsements.count(
+      BtcEndorsement::getId(vtbs1[0])));
+  EXPECT_TRUE(containingVbkBlock->containingEndorsements.count(
+      BtcEndorsement::getId(vtbs1[1])));
 
-  EXPECT_TRUE(containingVbkBlock->containingEndorsements.find(
-                  BtcEndorsement::fromContainer(vtbs1[1]).id) !=
-              containingVbkBlock->containingEndorsements.end());
-
-  EXPECT_EQ(alttree.vbk().getBestChain().tip()->getHash(), vbkTip1->getHash());
+  EXPECT_EQ(*alttree.vbk().getBestChain().tip(), *vbkTip1);
 }

--- a/test/entities/CMakeLists.txt
+++ b/test/entities/CMakeLists.txt
@@ -14,4 +14,3 @@ addtest(entities_serde_test
         altblock_test.cpp
         merkle_tree_test.cpp
         )
-target_link_libraries(entities_serde_test ${LIB_NAME})

--- a/test/rewards/CMakeLists.txt
+++ b/test/rewards/CMakeLists.txt
@@ -1,7 +1,5 @@
 addtest(poprewards_calculator_test
         poprewards_calculator_test.cpp)
-target_link_libraries(poprewards_calculator_test ${LIB_NAME})
 
 addtest(poprewards_test
         poprewards_test.cpp)
-target_link_libraries(poprewards_test ${LIB_NAME})

--- a/test/storage/CMakeLists.txt
+++ b/test/storage/CMakeLists.txt
@@ -1,23 +1,23 @@
 if(WITH_ROCKSDB)
     addtest(storage_test storage_test.cpp)
-    target_link_libraries(storage_test ${LIB_NAME} rocksdb)
+    target_link_libraries(storage_test rocksdb)
     set_target_properties(storage_test PROPERTIES
             RESOURCE_LOCK db-test
             )
 
     addtest(rocks_storage_test rocks_storage_test.cpp)
-    target_link_libraries(rocks_storage_test ${LIB_NAME} rocksdb)
+    target_link_libraries(rocks_storage_test rocksdb)
     set_target_properties(rocks_storage_test PROPERTIES
             RESOURCE_LOCK db-test
             )
     addtest(endorsement_storage_test endorsement_storage_test.cpp)
-    target_link_libraries(endorsement_storage_test ${LIB_NAME} rocksdb)
+    target_link_libraries(endorsement_storage_test rocksdb)
     set_target_properties(endorsement_storage_test PROPERTIES
             RESOURCE_LOCK db-test
             )
             
     addtest(payloads_storage_test payloads_storage_test.cpp)
-    target_link_libraries(payloads_storage_test ${LIB_NAME} rocksdb)
+    target_link_libraries(payloads_storage_test rocksdb)
     set_target_properties(payloads_storage_test PROPERTIES
             RESOURCE_LOCK db-test
             )

--- a/test/third_party/CMakeLists.txt
+++ b/test/third_party/CMakeLists.txt
@@ -1,7 +1,5 @@
 addtest(sha256_test sha256_test.cpp)
-target_link_libraries(sha256_test ${LIB_NAME})
 
 addtest(secp256k1_test secp256k1_test.cpp)
-target_link_libraries(secp256k1_test ${LIB_NAME})
 
 addtest(gmock_test gmock_test.cpp)


### PR DESCRIPTION
Optimize addPayloads by removing temp tree usage inside of PopComparator. Instead, add flag `bool atomic` to addPayloads, which if true, does copy of the whole PopComparator, to ensure atomicity.

AltTree calls VbkTree::addPayloads with atomic=false.