### PR TITLE
fix the endorsement time adjustment

### DIFF
--- a/include/veriblock/blockchain/pop/fork_resolution.hpp
+++ b/include/veriblock/blockchain/pop/fork_resolution.hpp
@@ -193,7 +193,7 @@ std::vector<ProtoKeystoneContext<ProtectingBlockT>> getProtoKeystoneContext(
        keystoneToConsider <= lastKeystone;
        keystoneToConsider = firstKeystoneAfter(keystoneToConsider, ki)) {
     ProtoKeystoneContext<ProtectingBlockT> pkc(
-        keystoneToConsider, chain[keystoneToConsider]->height);
+        keystoneToConsider, chain[keystoneToConsider]->getBlockTime());
 
     auto highestConnectingBlock =
         highestBlockWhichConnectsKeystoneToPrevious(keystoneToConsider, ki);
@@ -446,8 +446,8 @@ struct PopAwareForkResolutionComparator {
     auto ki = ed.getParams().getKeystoneInterval();
     const auto* fork = currentBest.findFork(&indexNew);
     VBK_ASSERT(fork != nullptr &&
-           "all blocks in a blocktree must form a tree, thus all pairs of "
-           "chains must have a fork point");
+               "all blocks in a blocktree must form a tree, thus all pairs of "
+               "chains must have a fork point");
 
     bool AcrossedKeystoneBoundary =
         isCrossedKeystoneBoundary(fork->height, bestTip->height, ki);

--- a/include/veriblock/entities/altblock.hpp
+++ b/include/veriblock/entities/altblock.hpp
@@ -57,6 +57,12 @@ struct AltBlock {
    */
   std::vector<uint8_t> toVbkEncoding() const;
 
+  /*
+   * Getter for timestamp
+   * @return block timestamp
+   */
+  uint32_t getBlockTime() const;
+
   hash_t getHash() const { return hash; }
 
   friend bool operator==(const AltBlock& a, const AltBlock& b) {

--- a/src/entities/altblock.cpp
+++ b/src/entities/altblock.cpp
@@ -48,3 +48,5 @@ std::vector<uint8_t> AltBlock::toVbkEncoding() const {
   toVbkEncoding(stream);
   return stream.data();
 }
+
+uint32_t AltBlock::getBlockTime() const { return timestamp; }


### PR DESCRIPTION
This breaks lots of tests. We can get the tests to pass by shifting timestamps of  genesis blocks: altchain << vbk << btc . But this would merely conceal the fact that tests are still broken.