### PR TITLE
fix state corruption in AddVTB on hitting the history overwrite limit and on attempting to add payloads to an invalid block; make addPayloads atomic; don't create invalid blocks in the mock miner

### DIFF
--- a/include/veriblock/blockchain/pop/vbk_block_tree.hpp
+++ b/include/veriblock/blockchain/pop/vbk_block_tree.hpp
@@ -56,8 +56,7 @@ struct VbkBlockTree : public BlockTree<VbkBlock, VbkChainParams> {
   bool bootstrapWithGenesis(ValidationState& state) override;
 
   /**
-   * @invariant NOT atomic. When addPayloads is called and fails -
-   * removePayloads have to be called on same payloads.
+   * @invariant atomic: adds either all or none of the payloads
    */
   bool addPayloads(const VbkBlock::hash_t& hash,
                    const std::vector<payloads_t>& payloads,

--- a/src/mock_miner.cpp
+++ b/src/mock_miner.cpp
@@ -288,6 +288,9 @@ VbkBlock MockMiner::applyVTBs(const BlockIndex<VbkBlock>& tip,
     throw std::domain_error(state.toString());
   }
   if (!tree.addPayloads(containingHash, vtbs, state)) {
+    auto* containingIndex = tree.getBlockIndex(containingHash);
+    VBK_ASSERT(containingIndex != nullptr);
+    tree.removeTip(*containingIndex);
     throw std::domain_error(state.toString());
   }
   vbkPayloads[containingHash] = vtbs;


### PR DESCRIPTION
… 