### PR TITLE
serialize valid flag in the storage serialization functions

### DIFF
--- a/src/blockchain/alt_block_tree.cpp
+++ b/src/blockchain/alt_block_tree.cpp
@@ -454,9 +454,6 @@ void AltTree::filterInvalidPayloads(PopData& pop) {
 
   // at this point `pop` contains only valid payloads
 
-  // TODO: flush payloads db on disk here (do not write on disk until this
-  // point)
-
   removeSubtree(*tmpindex);
 }
 

--- a/test/storage/payloads_storage_test.cpp
+++ b/test/storage/payloads_storage_test.cpp
@@ -108,14 +108,17 @@ TYPED_TEST_P(PayloadsRepoTest, Basic) {
 
   payloads_t p1 = generatePayloads<payloads_t>();
   payloads_t p2 = generatePayloads<payloads_t>();
+  p1.valid = false;
+  p2.valid = false;
   this->repo->put(p1);
   this->repo->put(p2);
 
   payloads_t stored_p;
   EXPECT_TRUE(this->repo->get(p1.getId(), &stored_p));
   EXPECT_EQ(stored_p, p1);
+  EXPECT_EQ(stored_p.valid, p1.valid);
   EXPECT_TRUE(this->repo->get(p2.getId(), &stored_p));
-  EXPECT_EQ(stored_p, p2);
+  EXPECT_EQ(stored_p.valid, p2.valid);
 
   this->repo->removeByHash(p2.getId());
 


### PR DESCRIPTION
Before we have cache in the RocksDB implementation, we need to store the validity flag.