### PR TITLE
ALT-405: Change RPC call addnode argument to onetry

### DIFF
--- a/pypoptools/pypoptesting/vbitcoind_node.py
+++ b/pypoptools/pypoptesting/vbitcoind_node.py
@@ -139,7 +139,7 @@ class VBitcoindNode(Node):
 
     def connect(self, node):
         ip_port = "{}:{}".format(BIND_TO, node.p2p_port)
-        self.rpc.addnode(ip_port, 'add')
+        self.rpc.addnode(ip_port, 'onetry')
         # poll until version handshake complete to avoid race conditions
         # with transaction relaying
         wait_until(lambda: all(peer['version'] != 0 for peer in self.rpc.getpeerinfo()))


### PR DESCRIPTION
https://track.veriblock.org/issue/ALT-405