### PR TITLE
Change comparePopScore log level

### DIFF
--- a/src/pop/blockchain/alt_block_tree.cpp
+++ b/src/pop/blockchain/alt_block_tree.cpp
@@ -362,7 +362,7 @@ int AltBlockTree::comparePopScore(const AltBlock::hash_t& A,
     activeChain_.setTip(right);
   }
 
-  VBK_LOG_WARN(
+  VBK_LOG_DEBUG(
       "Comparing two chains. Current tip: %s, Candidate: %s. Result: %s (%d), "
       "reason: %s.",
       left->toShortPrettyString(),


### PR DESCRIPTION
I assume we should change the log level for the comparePopScore result to the `VBK_LOG_DEBUG` or `VBK_LOG_INFO`