### PR TITLE
Revert "Pass AltChainParams in deserialize."

### DIFF
--- a/.github/workflows/pypoptools.yml
+++ b/.github/workflows/pypoptools.yml
@@ -35,7 +35,7 @@ jobs:
           clean: true
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.x'
           architecture: 'x64'
       - name: install reqs on ubuntu
         if: matrix.runson == 'ubuntu-latest'

--- a/bindings/go/api/altblock.go
+++ b/bindings/go/api/altblock.go
@@ -94,11 +94,11 @@ func (v *AltBlock) SerializeToVbk() []byte {
 	return createBytes(&res)
 }
 
-func (v *AltBlock) DeserializeFromVbkAltBlock(bytes []byte, config *Config) error {
+func (v *AltBlock) DeserializeFromVbkAltBlock(bytes []byte) error {
 	state := NewValidationState()
 	defer state.Free()
 
-	res := C.pop_alt_block_deserialize_from_vbk(createCBytes(bytes), state.ref, config.ref)
+	res := C.pop_alt_block_deserialize_from_vbk(createCBytes(bytes), state.ref)
 	if res == nil {
 		return state.Error()
 	}

--- a/bindings/go/api/btcblock.go
+++ b/bindings/go/api/btcblock.go
@@ -112,11 +112,11 @@ func (v *BtcBlock) SerializeToVbk() []byte {
 	return createBytes(&res)
 }
 
-func (v *BtcBlock) DeserializeFromVbk(bytes []byte, config *Config) error {
+func (v *BtcBlock) DeserializeFromVbk(bytes []byte) error {
 	state := NewValidationState()
 	defer state.Free()
 
-	res := C.pop_btc_block_deserialize_from_vbk(createCBytes(bytes), state.ref, config.ref)
+	res := C.pop_btc_block_deserialize_from_vbk(createCBytes(bytes), state.ref)
 	if res == nil {
 		return state.Error()
 	}

--- a/bindings/go/api/config_test.go
+++ b/bindings/go/api/config_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestConfigFree(t *testing.T) {
+	t.Parallel()
 
 	config := NewConfig()
 
@@ -20,15 +21,12 @@ func TestConfigFree(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
 	config := NewConfig()
 	defer config.Free()
-
-	SetOnGetBootstrapBlock(func() AltBlock {
-		return *GenerateDefaultAltBlock()
-	})
 
 	config.SelectVbkParams("regtest", 0, "")
 	config.SelectBtcParams("regtest", 0, "")

--- a/bindings/go/api/entities_json_test.go
+++ b/bindings/go/api/entities_json_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestJSONBtcBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -30,6 +31,7 @@ func TestJSONBtcBlock(t *testing.T) {
 }
 
 func TestJSONVbkBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -52,6 +54,7 @@ func TestJSONVbkBlock(t *testing.T) {
 }
 
 func TestJSONAltBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -60,13 +63,14 @@ func TestJSONAltBlock(t *testing.T) {
 	json, err := alt_block.ToJSON(true)
 	assert.NoError(err)
 
-	assert.Equal(json["hash"], "0101010101010101010101010101010101010101010101010101010101010101")
-	assert.Equal(json["previousBlock"], "0202020202020202020202020202020202020202020202020202020202020202")
+	assert.Equal(json["hash"], "01010101010101010101010101010101")
+	assert.Equal(json["previousBlock"], "02020202020202020202020202020202")
 	assert.Equal(json["timestamp"], float64(1))
 	assert.Equal(json["height"], float64(1))
 }
 
 func TestJSONVtb(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -82,6 +86,7 @@ func TestJSONVtb(t *testing.T) {
 }
 
 func TestJSONAtv(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 

--- a/bindings/go/api/entities_test.go
+++ b/bindings/go/api/entities_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestBtcBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -33,6 +34,7 @@ func TestBtcBlock(t *testing.T) {
 }
 
 func TestVbkBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -56,6 +58,7 @@ func TestVbkBlock(t *testing.T) {
 }
 
 func TestAltBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -63,14 +66,15 @@ func TestAltBlock(t *testing.T) {
 
 	assert.Equal(alt_block.GetHeight(), int32(1))
 	assert.Equal(alt_block.GetTimestamp(), uint32(1))
-	assert.Equal(alt_block.GetHash(), []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1})
-	assert.Equal(alt_block.GetPreviousBlock(), []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2})
+	assert.Equal(alt_block.GetHash(), []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1})
+	assert.Equal(alt_block.GetPreviousBlock(), []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2})
 
 	alt_block.Free()
 	alt_block.Free()
 }
 
 func TestVtb(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -94,6 +98,7 @@ func TestVtb(t *testing.T) {
 }
 
 func TestAtv(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -117,6 +122,7 @@ func TestAtv(t *testing.T) {
 }
 
 func TestPopData(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -147,6 +153,7 @@ func TestPopData(t *testing.T) {
 }
 
 func TestNetworkBytePair(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -161,6 +168,7 @@ func TestNetworkBytePair(t *testing.T) {
 }
 
 func TestAddress(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -174,6 +182,7 @@ func TestAddress(t *testing.T) {
 }
 
 func TestBtcTx(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -186,6 +195,7 @@ func TestBtcTx(t *testing.T) {
 }
 
 func TestCoin(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -198,6 +208,7 @@ func TestCoin(t *testing.T) {
 }
 
 func TestMerklePath(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -219,6 +230,7 @@ func TestMerklePath(t *testing.T) {
 }
 
 func TestPopPayout(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -232,6 +244,7 @@ func TestPopPayout(t *testing.T) {
 }
 
 func TestContextInfoContainer(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 

--- a/bindings/go/api/mempool_test.go
+++ b/bindings/go/api/mempool_test.go
@@ -12,17 +12,15 @@ import (
 )
 
 func TestPopContextMemPoolSubmitAll(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 
@@ -85,17 +83,15 @@ func TestPopContextMemPoolSubmitAll(t *testing.T) {
 }
 
 func TestPopContextMemPoolSubmitStatefullFailed(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 
@@ -158,14 +154,11 @@ func TestPopContextMemPoolSubmitStatefullFailed(t *testing.T) {
 func TestPopContextMempoolGeneratePopData(t *testing.T) {
 	assert := assert.New(t)
 
-	config := NewConfig()
-	defer config.Free()
-
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 

--- a/bindings/go/api/mock_miner_test.go
+++ b/bindings/go/api/mock_miner_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMockMinerFree(t *testing.T) {
+	t.Parallel()
 
 	mockMiner := NewMockMiner()
 	defer mockMiner.Lock()()
@@ -20,6 +21,7 @@ func TestMockMinerFree(t *testing.T) {
 }
 
 func TestMineBtcBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -50,6 +52,7 @@ func TestMineBtcBlock(t *testing.T) {
 }
 
 func TestMineVbkBlock(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -80,6 +83,7 @@ func TestMineVbkBlock(t *testing.T) {
 }
 
 func TestMineVtb(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 

--- a/bindings/go/api/pop_context.go
+++ b/bindings/go/api/pop_context.go
@@ -40,7 +40,6 @@ func NewPopContext(config *Config, storage *Storage, log_lvl string) *PopContext
 
 func (v *PopContext) Free() {
 	v.mutex.AssertMutexLocked("PopContext is not locked")
-
 	if v.ref != nil {
 		C.pop_pop_context_free(v.ref)
 		v.ref = nil

--- a/bindings/go/api/pop_context_test.go
+++ b/bindings/go/api/pop_context_test.go
@@ -12,17 +12,15 @@ import (
 )
 
 func TestPopContextFree(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 
 	context.Free()
@@ -30,17 +28,15 @@ func TestPopContextFree(t *testing.T) {
 }
 
 func TestPopContextBlockPrecessing(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 

--- a/bindings/go/api/serde_test.go
+++ b/bindings/go/api/serde_test.go
@@ -31,16 +31,14 @@ func assertHexDecode(str string) []byte {
 }
 
 func TestAltBlockSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultAltBlockEncoded)
 
 	block := NewAltBlock([]byte{}, []byte{}, 0, 0)
-	err := block.DeserializeFromVbkAltBlock(encodedBytes, config)
+	err := block.DeserializeFromVbkAltBlock(encodedBytes)
 	assert.NoError(err)
 	assert.NotNil(block)
 
@@ -51,21 +49,19 @@ func TestAltBlockSerde(t *testing.T) {
 
 	assert.Equal(block.SerializeToVbk(), encodedBytes)
 
-	err = block.DeserializeFromVbkAltBlock([]byte{1, 2, 3, 4}, config)
+	err = block.DeserializeFromVbkAltBlock([]byte{1, 2, 3, 4})
 	assert.Error(err)
 }
 
 func TestVbkBlockSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultVbkBlockEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(encodedBytes, config)
+	err := vbkBlock.DeserializeFromVbk(encodedBytes)
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -81,21 +77,19 @@ func TestVbkBlockSerde(t *testing.T) {
 
 	assert.Equal(vbkBlock.SerializeToVbk(), encodedBytes)
 
-	err = vbkBlock.DeserializeFromVbk([]byte{1, 2, 3, 4}, config)
+	err = vbkBlock.DeserializeFromVbk([]byte{1, 2, 3, 4})
 	assert.Error(err)
 }
 
 func TestBtcBlockSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultBtcBlockEncoded)
 
 	btcBlock := CreateBtcBlock()
-	err := btcBlock.DeserializeFromVbk(encodedBytes, config)
+	err := btcBlock.DeserializeFromVbk(encodedBytes)
 	assert.NoError(err)
 	assert.NotNil(btcBlock)
 
@@ -108,21 +102,19 @@ func TestBtcBlockSerde(t *testing.T) {
 
 	assert.Equal(btcBlock.SerializeToVbk(), encodedBytes)
 
-	err = btcBlock.DeserializeFromVbk([]byte{1, 2, 3, 4}, config)
+	err = btcBlock.DeserializeFromVbk([]byte{1, 2, 3, 4})
 	assert.Error(err)
 }
 
 func TestVtbSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultVtbEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
+	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -140,16 +132,14 @@ func TestVtbSerde(t *testing.T) {
 }
 
 func TestAtvSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultAtvEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
+	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -167,6 +157,7 @@ func TestAtvSerde(t *testing.T) {
 }
 
 func TestPublicationDataSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -184,11 +175,9 @@ func TestPublicationDataSerde(t *testing.T) {
 }
 
 func TestPopDataSerde(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	encodedBytes := assertHexDecode(defaultPopDataEncoded)
 
@@ -203,7 +192,7 @@ func TestPopDataSerde(t *testing.T) {
 	assert.NotNil(vtb)
 
 	vbkBlock := CreateVbkBlock()
-	err = vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
+	err = vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 

--- a/bindings/go/api/storage_test.go
+++ b/bindings/go/api/storage_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestStorageFree(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 
@@ -23,6 +24,7 @@ func TestStorageFree(t *testing.T) {
 }
 
 func TestCreateStorageFailure(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 

--- a/bindings/go/api/test_util.go
+++ b/bindings/go/api/test_util.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 )
 
-func GenerateTestPopContext(t *testing.T, storage *Storage, config *Config) *PopContext {
+func GenerateTestPopContext(t *testing.T, storage *Storage) *PopContext {
+	config := NewConfig()
+	defer config.Free()
+
 	config.SelectVbkParams("regtest", 0, "")
 	config.SelectBtcParams("regtest", 0, "")
 
@@ -21,7 +24,7 @@ func GenerateTestPopContext(t *testing.T, storage *Storage, config *Config) *Pop
 	})
 	SetOnGetBlockHeaderHash(func(header []byte) []byte {
 		altblock := NewAltBlock([]byte{}, []byte{}, 0, 0)
-		err := altblock.DeserializeFromVbkAltBlock(header, config)
+		err := altblock.DeserializeFromVbkAltBlock(header)
 		if err != nil {
 			panic(err)
 		}

--- a/bindings/go/api/utils_test.go
+++ b/bindings/go/api/utils_test.go
@@ -14,16 +14,14 @@ import (
 )
 
 func TestGeneratePublicationData(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 
@@ -47,17 +45,15 @@ func TestGeneratePublicationData(t *testing.T) {
 }
 
 func TestCalculateTopLevelMerkleRoot(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
-
-	config := NewConfig()
-	defer config.Free()
 
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 
@@ -78,14 +74,11 @@ func TestCalculateTopLevelMerkleRoot(t *testing.T) {
 func TestCheckAll(t *testing.T) {
 	assert := assert.New(t)
 
-	config := NewConfig()
-	defer config.Free()
-
 	storage, err := NewStorage(":inmem:")
 	assert.NoError(err)
 	defer storage.Free()
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 
@@ -138,15 +131,12 @@ func TestSaveLoadAllTrees(t *testing.T) {
 
 	defer os.RemoveAll("/tmp/alt-integration")
 
-	config := NewConfig()
-	defer config.Free()
-
 	storage, err := NewStorage("/tmp/alt-integration")
 	defer storage.Free()
 
 	assert.NoError(err)
 
-	context := GenerateTestPopContext(t, storage, config)
+	context := GenerateTestPopContext(t, storage)
 	unlock := context.Lock()
 
 	// generate new block
@@ -202,7 +192,7 @@ func TestSaveLoadAllTrees(t *testing.T) {
 
 	context.Free()
 	unlock()
-	context = GenerateTestPopContext(t, storage, config)
+	context = GenerateTestPopContext(t, storage)
 	defer context.Lock()()
 	defer context.Free()
 

--- a/bindings/go/api/validation_state_test.go
+++ b/bindings/go/api/validation_state_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestValidationStateFree(t *testing.T) {
+	t.Parallel()
 
 	state := NewValidationState()
 
@@ -20,6 +21,7 @@ func TestValidationStateFree(t *testing.T) {
 }
 
 func TestValidationStateBasic(t *testing.T) {
+	t.Parallel()
 
 	assert := assert.New(t)
 

--- a/bindings/go/api/vbkblock.go
+++ b/bindings/go/api/vbkblock.go
@@ -155,11 +155,11 @@ func (v *VbkBlock) SerializeToVbk() []byte {
 	return createBytes(&res)
 }
 
-func (v *VbkBlock) DeserializeFromVbk(bytes []byte, config *Config) error {
+func (v *VbkBlock) DeserializeFromVbk(bytes []byte) error {
 	state := NewValidationState()
 	defer state.Free()
 
-	res := C.pop_vbk_block_deserialize_from_vbk(createCBytes(bytes), state.ref, config.ref)
+	res := C.pop_vbk_block_deserialize_from_vbk(createCBytes(bytes), state.ref)
 	if res == nil {
 		return state.Error()
 	}

--- a/fuzz/deserialization_fuzz.cpp
+++ b/fuzz/deserialization_fuzz.cpp
@@ -4,7 +4,6 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 #include <type_traits>
-#include <veriblock/pop/blockchain/alt_chain_params.hpp>
 #include <veriblock/pop/entities/altblock.hpp>
 #include <veriblock/pop/entities/context_info_container.hpp>
 #include <veriblock/pop/entities/keystone_container.hpp>
@@ -41,9 +40,9 @@ getEstimateSize(const T&) {
 }
 
 using altintegration::AltBlock;
+using altintegration::StoredBlockIndex;
 using altintegration::BlockIndex;
 using altintegration::BtcBlock;
-using altintegration::StoredBlockIndex;
 using altintegration::VbkBlock;
 
 // clang-format off
@@ -53,15 +52,14 @@ template <> BlockIndex<VbkBlock> create() { return BlockIndex<VbkBlock>{0}; }
 template <> BlockIndex<AltBlock> create() { return BlockIndex<AltBlock>{0}; }
 // clang-format on
 
-#define DEFINE_DESER_FUZZ(type, ...)                                           \
+#define DEFINE_DESER_FUZZ(type)                                                \
   {                                                                            \
     auto value = create<type>();                                               \
-    if (DeserializeFromVbkEncoding(stream, value, state, ##__VA_ARGS__)) {     \
+    if (DeserializeFromVbkEncoding(stream, value, state)) {                    \
       WriteStream w;                                                           \
       value.toVbkEncoding(w);                                                  \
       auto value2 = create<type>();                                            \
-      if (!DeserializeFromVbkEncoding(                                         \
-              w.data(), value2, state, ##__VA_ARGS__)) {                       \
+      if (!DeserializeFromVbkEncoding(w.data(), value2, state)) {              \
         /* we serialized an entity but were not able to deserialize it back */ \
         VBK_ASSERT_MSG(false,                                                  \
                        "type=%s\nbytes=%s\nstate=%s",                          \
@@ -69,7 +67,7 @@ template <> BlockIndex<AltBlock> create() { return BlockIndex<AltBlock>{0}; }
                        HexStr(w.data()),                                       \
                        state.toString());                                      \
       }                                                                        \
-      /* if deserialized value is not same as "before serialization", die */   \
+      /* if deserialized value is not same as "before serialization", die */  \
       auto A = SerializeToHex(value);                                          \
       auto B = SerializeToHex(value2);                                         \
       VBK_ASSERT_MSG(A == B, "A=%s\nB=%s\n", A, B);                            \
@@ -111,9 +109,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
   DEFINE_DESER_FUZZ(KeystoneContainer);
   DEFINE_DESER_FUZZ(ContextInfoContainer);
   DEFINE_DESER_FUZZ(AuthenticatedContextInfoContainer);
-  DEFINE_DESER_FUZZ(AltBlock, AltChainParamsRegTest{});
-  DEFINE_DESER_FUZZ(BtcBlock, AltChainParamsRegTest{});
-  DEFINE_DESER_FUZZ(VbkBlock, AltChainParamsRegTest{});
+  DEFINE_DESER_FUZZ(AltBlock);
+  DEFINE_DESER_FUZZ(BtcBlock);
+  DEFINE_DESER_FUZZ(VbkBlock);
   DEFINE_DESER_FUZZ(VbkEndorsement);
   DEFINE_DESER_FUZZ(AltEndorsement);
   DEFINE_DESER_FUZZ(VbkPopTx);
@@ -123,12 +121,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
   DEFINE_DESER_FUZZ(StoredBtcBlockAddon);
   DEFINE_DESER_FUZZ(StoredVbkBlockAddon);
   DEFINE_DESER_FUZZ(StoredAltBlockAddon);
-  DEFINE_DESER_FUZZ(StoredBlockIndex<AltBlock>, AltChainParamsRegTest{});
-  DEFINE_DESER_FUZZ(StoredBlockIndex<VbkBlock>, AltChainParamsRegTest{});
-  DEFINE_DESER_FUZZ(StoredBlockIndex<BtcBlock>, AltChainParamsRegTest{});
+  DEFINE_DESER_FUZZ(StoredBlockIndex<AltBlock>);
+  DEFINE_DESER_FUZZ(StoredBlockIndex<VbkBlock>);
+  DEFINE_DESER_FUZZ(StoredBlockIndex<BtcBlock>);
   DEFINE_DESER_FUZZ(BtcBlockAddon);
   DEFINE_DESER_FUZZ(VbkBlockAddon);
   DEFINE_DESER_FUZZ(AltBlockAddon);
+  DEFINE_DESER_FUZZ(BlockIndex<AltBlock>);
+  DEFINE_DESER_FUZZ(BlockIndex<VbkBlock>);
+  DEFINE_DESER_FUZZ(BlockIndex<BtcBlock>);
   DEFINE_DESER_FUZZ(VTB);
   DEFINE_DESER_FUZZ(ATV);
   DEFINE_DESER_FUZZ(PopData);

--- a/fuzz/e2e/tree.cpp
+++ b/fuzz/e2e/tree.cpp
@@ -86,7 +86,7 @@ Tree::Tree() {
   bestBlock = genesisBlock.hash;
   params = std::make_shared<FuzzAltChainParams>();
   pp = std::make_shared<altintegration::adaptors::PayloadsStorageImpl>(storage);
-  bp = std::make_shared<altintegration::adaptors::BlockReaderImpl>(storage, *params);
+  bp = std::make_shared<altintegration::adaptors::BlockReaderImpl>(storage);
 
   auto config = std::make_shared<altintegration::Config>();
   config->SelectBtcParams("regtest", 0, {});

--- a/include/veriblock/pop/blockchain/alt_chain_params.hpp
+++ b/include/veriblock/pop/blockchain/alt_chain_params.hpp
@@ -271,40 +271,8 @@ struct AltChainParams {
   size_t mMaxVTBsInAltBlock = 200;
   size_t mMaxATVsInAltBlock = 1000;
 
-  uint32_t mAltBlockHashSize = SHA256_HASH_SIZE;
-
   std::vector<uint32_t> mForkResolutionLookUpTable{
       100, 100, 95, 89, 80, 69, 56, 40, 21};
-};
-
-struct AltChainParamsRegTest : public AltChainParams {
-  AltChainParamsRegTest(int id = 0) : id(id) {}
-  ~AltChainParamsRegTest() override = default;
-
-  AltBlock getBootstrapBlock() const noexcept override {
-    AltBlock b;
-    b.hash = std::vector<uint8_t>(SHA256_HASH_SIZE, 1);
-    b.previousBlock = std::vector<uint8_t>(SHA256_HASH_SIZE, 0);
-    b.height = 0;
-    b.timestamp = 0;
-    return b;
-  }
-
-  int64_t getIdentifier() const noexcept override { return id; }
-
-  std::vector<uint8_t> getHash(
-      const std::vector<uint8_t>& bytes) const noexcept override {
-    return AssertDeserializeFromRaw<AltBlock>(bytes, *this).getHash();
-  }
-
-  bool checkBlockHeader(const std::vector<uint8_t>& bytes,
-                        const std::vector<uint8_t>&,
-                        ValidationState& state) const noexcept override {
-    AltBlock block;
-    return DeserializeFromRaw<AltBlock>(bytes, block, state, *this);
-  }
-
-  int64_t id = 0;
 };
 
 //! @overload

--- a/include/veriblock/pop/blockchain/block_index.hpp
+++ b/include/veriblock/pop/blockchain/block_index.hpp
@@ -10,6 +10,7 @@
 #include <set>
 #include <vector>
 #include <veriblock/pop/algorithm.hpp>
+#include <veriblock/pop/arith_uint256.hpp>
 #include <veriblock/pop/entities/endorsements.hpp>
 #include <veriblock/pop/entities/vbkblock.hpp>
 #include <veriblock/pop/logger.hpp>
@@ -368,6 +369,22 @@ struct BlockIndex : public Block::addon_t {
     return format("{}:{}:{}", Block::name(), height, HexStr(getHash()));
   }
 
+  void toVbkEncoding(WriteStream& stream) const {
+    using height_t = typename Block::height_t;
+    stream.writeBE<height_t>(height);
+    header->toRaw(stream);
+    stream.writeBE<uint32_t>(status);
+
+    const addon_t* t = this;
+    t->toVbkEncoding(stream);
+  }
+
+  std::vector<uint8_t> toVbkEncoding() const {
+    WriteStream stream;
+    toVbkEncoding(stream);
+    return stream.data();
+  }
+
   friend bool operator==(const BlockIndex& a, const BlockIndex& b) {
     return a.getStatus() == b.getStatus() && a.getHeight() == b.getHeight() &&
            a.getHeader() == b.getHeader();
@@ -390,6 +407,12 @@ struct BlockIndex : public Block::addon_t {
 
   //! (memory only) if true, this block should be written on disk
   bool dirty = false;
+
+  template <typename T>
+  friend bool DeserializeFromVbkEncoding(ReadStream& stream,
+                                         BlockIndex<T>& out,
+                                         ValidationState& state,
+                                         typename T::hash_t precalculatedHash);
 
  private:
   // make it non-copyable
@@ -463,6 +486,36 @@ bool isBlockOutdated(const BlockIndex<Block>& finalBlock,
 template <typename Block>
 void PrintTo(const BlockIndex<Block>& b, ::std::ostream* os) {
   *os << b.toPrettyString();
+}
+
+//! @overload
+template <typename Block>
+bool DeserializeFromVbkEncoding(
+    ReadStream& stream,
+    BlockIndex<Block>& out,
+    ValidationState& state,
+    typename Block::hash_t precalculatedHash = typename Block::hash_t()) {
+  const auto& name = Block::name();
+  using height_t = typename Block::height_t;
+  if (!stream.readBE<height_t>(out.height, state)) {
+    return state.Invalid(name + "-block-index-height");
+  }
+  Block block{};
+  if (!DeserializeFromRaw(stream, block, state, precalculatedHash)) {
+    return state.Invalid(name + "-block-index-header");
+  }
+  out.setHeader(block);
+  if (!stream.readBE<uint32_t>(out.status, state)) {
+    return state.Invalid(name + "-block-index-status");
+  }
+
+  using addon_t = typename Block::addon_t;
+  addon_t& addon = out;
+  if (!DeserializeFromVbkEncoding(stream, addon, state)) {
+    return state.Invalid(name + "-block-index-addon");
+  }
+  out.unsetDirty();
+  return true;
 }
 
 }  // namespace altintegration

--- a/include/veriblock/pop/c/entities/altblock.h
+++ b/include/veriblock/pop/c/entities/altblock.h
@@ -16,8 +16,6 @@
 extern "C" {
 #endif
 
-POP_DECLARE_ENTITY(config);
-
 POP_DECLARE_ENTITY(alt_block);
 
 POP_ENTITY_NEW_FUNCTION(alt_block,
@@ -34,7 +32,7 @@ POP_ENTITY_GETTER_FUNCTION(alt_block, int32_t, height);
 POP_ENTITY_TO_JSON(alt_block, bool reverseHashes);
 
 POP_ENTITY_SERIALIZE_TO_VBK(alt_block);
-POP_ENTITY_DESERIALIZE_FROM_VBK(alt_block, POP_ENTITY_NAME(config) *);
+POP_ENTITY_DESERIALIZE_FROM_VBK(alt_block);
 
 POP_GENERATE_DEFAULT_VALUE(alt_block);
 

--- a/include/veriblock/pop/c/entities/btcblock.h
+++ b/include/veriblock/pop/c/entities/btcblock.h
@@ -14,8 +14,6 @@
 extern "C" {
 #endif
 
-POP_DECLARE_ENTITY(config);
-
 POP_DECLARE_ENTITY(btc_block);
 
 POP_ENTITY_GETTER_FUNCTION(btc_block, POP_ARRAY_NAME(u8), hash);
@@ -29,7 +27,7 @@ POP_ENTITY_GETTER_FUNCTION(btc_block, uint32_t, nonce);
 POP_ENTITY_TO_JSON(btc_block);
 
 POP_ENTITY_SERIALIZE_TO_VBK(btc_block);
-POP_ENTITY_DESERIALIZE_FROM_VBK(btc_block, POP_ENTITY_NAME(config) *);
+POP_ENTITY_DESERIALIZE_FROM_VBK(btc_block);
 
 POP_DECLARE_ARRAY(POP_ENTITY_NAME(btc_block) *, btc_block);
 

--- a/include/veriblock/pop/c/entities/serde.h
+++ b/include/veriblock/pop/c/entities/serde.h
@@ -17,11 +17,9 @@ extern "C" {
   POP_ARRAY_NAME(u8)                        \
   pop_##entity##_serialize_to_vbk(const pop_##entity##_t* self)
 
-#define POP_ENTITY_DESERIALIZE_FROM_VBK(entity, ...)     \
+#define POP_ENTITY_DESERIALIZE_FROM_VBK(entity)          \
   pop_##entity##_t* pop_##entity##_deserialize_from_vbk( \
-      POP_ARRAY_NAME(u8) bytes,                          \
-      POP_ENTITY_NAME(validation_state) * state,         \
-      ##__VA_ARGS__)
+      POP_ARRAY_NAME(u8) bytes, POP_ENTITY_NAME(validation_state) * state)
 
 #ifdef __cplusplus
 }

--- a/include/veriblock/pop/c/entities/vbkblock.h
+++ b/include/veriblock/pop/c/entities/vbkblock.h
@@ -14,8 +14,6 @@
 extern "C" {
 #endif
 
-POP_DECLARE_ENTITY(config);
-
 POP_DECLARE_ENTITY(vbk_block);
 
 POP_ENTITY_GETTER_FUNCTION(vbk_block, POP_ARRAY_NAME(u8), id);
@@ -35,7 +33,7 @@ POP_ENTITY_GETTER_FUNCTION(vbk_block, int32_t, height);
 POP_ENTITY_TO_JSON(vbk_block);
 
 POP_ENTITY_SERIALIZE_TO_VBK(vbk_block);
-POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block, POP_ENTITY_NAME(config) *);
+POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block);
 
 POP_DECLARE_ARRAY(POP_ENTITY_NAME(vbk_block) *, vbk_block);
 

--- a/include/veriblock/pop/entities/altblock.hpp
+++ b/include/veriblock/pop/entities/altblock.hpp
@@ -19,7 +19,6 @@
 namespace altintegration {
 
 struct VbkBlock;
-struct AltChainParams;
 
 /**
  * @class AltBlock
@@ -107,7 +106,6 @@ bool DeserializeFromRaw(
     ReadStream& stream,
     AltBlock& out,
     ValidationState& state,
-    const AltChainParams& params,
     const AltBlock::hash_t& /* ignore */ = AltBlock::hash_t{});
 
 //! @overload
@@ -115,7 +113,6 @@ bool DeserializeFromVbkEncoding(
     ReadStream& stream,
     AltBlock& out,
     ValidationState& state,
-    const AltChainParams& params,
     const AltBlock::hash_t& /* ignore */ = AltBlock::hash_t{});
 
 }  // namespace altintegration

--- a/include/veriblock/pop/entities/btcblock.hpp
+++ b/include/veriblock/pop/entities/btcblock.hpp
@@ -146,22 +146,6 @@ bool DeserializeFromRaw(
     ReadStream& stream,
     BtcBlock& out,
     ValidationState& state,
-    const AltChainParams& /*ignore*/,
-    const BtcBlock::hash_t& precalculatedHash = BtcBlock::hash_t{});
-
-//! @overload
-bool DeserializeFromRaw(
-    ReadStream& stream,
-    BtcBlock& out,
-    ValidationState& state,
-    const BtcBlock::hash_t& precalculatedHash = BtcBlock::hash_t{});
-
-//! @overload
-bool DeserializeFromVbkEncoding(
-    ReadStream& stream,
-    BtcBlock& out,
-    ValidationState& state,
-    const AltChainParams& /*ignore*/,
     const BtcBlock::hash_t& precalculatedHash = BtcBlock::hash_t{});
 
 //! @overload

--- a/include/veriblock/pop/entities/vbkblock.hpp
+++ b/include/veriblock/pop/entities/vbkblock.hpp
@@ -195,21 +195,6 @@ bool DeserializeFromRaw(ReadStream& stream,
                         const VbkBlock::hash_t& hash = VbkBlock::hash_t{});
 
 //! @overload
-bool DeserializeFromRaw(ReadStream& stream,
-                        VbkBlock& out,
-                        ValidationState& state,
-                        const AltChainParams& /*ignore*/,
-                        const VbkBlock::hash_t& hash = VbkBlock::hash_t{});
-
-//! @overload
-bool DeserializeFromVbkEncoding(
-    ReadStream& stream,
-    VbkBlock& out,
-    ValidationState& state,
-    const AltChainParams& /*ignore*/,
-    const VbkBlock::hash_t& hash = VbkBlock::hash_t{});
-
-//! @overload
 bool DeserializeFromVbkEncoding(
     ReadStream& stream,
     VbkBlock& out,

--- a/include/veriblock/pop/mock_miner.hpp
+++ b/include/veriblock/pop/mock_miner.hpp
@@ -162,10 +162,9 @@ class MockMiner {
 
   BtcChainParamsRegTest btc_params_{};
   VbkChainParamsRegTest vbk_params_{};
-  AltChainParamsRegTest alt_params_{};
   adaptors::InmemStorageImpl storage_{};
   adaptors::PayloadsStorageImpl payloads_provider_{storage_};
-  adaptors::BlockReaderImpl block_provider_{storage_, alt_params_};
+  adaptors::BlockReaderImpl block_provider_{storage_};
   PayloadsIndex payloads_index_;
 
   Miner<BtcBlock, BtcChainParams> btc_miner_ =

--- a/include/veriblock/pop/serde.hpp
+++ b/include/veriblock/pop/serde.hpp
@@ -24,8 +24,6 @@
 
 namespace altintegration {
 
-struct AltChainParams;
-
 /**
  * Checks if expression 'min' <= 'num' <= 'max' is true. If false, returns
  * invalid state with error description.
@@ -348,16 +346,6 @@ bool DeserializeFromVbkEncoding(Slice<const uint8_t> data,
   return DeserializeFromVbkEncoding(stream, out, state);
 }
 
-//! Deserialize from VBK encoding.
-template <typename T>
-bool DeserializeFromVbkEncoding(Slice<const uint8_t> data,
-                                T& out,
-                                ValidationState& state,
-                                const AltChainParams& params) {
-  ReadStream stream(data);
-  return DeserializeFromVbkEncoding(stream, out, state, params);
-}
-
 //! Deserialize from RAW encoding.
 template <typename T>
 bool DeserializeFromRaw(Slice<const uint8_t> data,
@@ -365,16 +353,6 @@ bool DeserializeFromRaw(Slice<const uint8_t> data,
                         ValidationState& state) {
   ReadStream stream(data);
   return DeserializeFromRaw(stream, out, state);
-}
-
-//! Deserialize from RAW encoding.
-template <typename T>
-bool DeserializeFromRaw(Slice<const uint8_t> data,
-                        T& out,
-                        ValidationState& state,
-                        const AltChainParams& params) {
-  ReadStream stream(data);
-  return DeserializeFromRaw(stream, out, state, params);
 }
 
 //! Deserialize from HEX VBK encoding.
@@ -385,17 +363,6 @@ bool DeserializeFromHex(const std::string& hex,
   auto data = ParseHex(hex);
   ReadStream stream(data);
   return DeserializeFromVbkEncoding(stream, out, state);
-}
-
-//! Deserialize from HEX VBK encoding.
-template <typename T>
-bool DeserializeFromHex(const std::string& hex,
-                        T& out,
-                        ValidationState& state,
-                        const AltChainParams& params) {
-  auto data = ParseHex(hex);
-  ReadStream stream(data);
-  return DeserializeFromVbkEncoding(stream, out, state, params);
 }
 
 //! Deserialize from HEX RAW encoding.
@@ -447,18 +414,6 @@ T AssertDeserializeFromRaw(std::vector<uint8_t> raw) {
   return t;
 }
 
-//! Deserialize from RAW encoding.
-//! @note will fail on assert if can't be deserialized.
-template <typename T>
-T AssertDeserializeFromRaw(std::vector<uint8_t> raw,
-                           const AltChainParams& params) {
-  T t;
-  ValidationState state;
-  bool result = DeserializeFromRaw(raw, t, state, params);
-  VBK_ASSERT_MSG(result, "Can't deserialize: %s", state.toString());
-  return t;
-}
-
 //! Deserialize from VBK encoding.
 //! @note will fail on assert if can't be deserialized.
 template <typename T>
@@ -466,18 +421,6 @@ T AssertDeserializeFromVbkEncoding(Slice<const uint8_t> raw) {
   T t;
   ValidationState state;
   bool result = DeserializeFromVbkEncoding(raw, t, state);
-  VBK_ASSERT_MSG(result, "Can't deserialize: %s", state.toString());
-  return t;
-}
-
-//! Deserialize from VBK encoding.
-//! @note will fail on assert if can't be deserialized.
-template <typename T>
-T AssertDeserializeFromVbkEncoding(Slice<const uint8_t> raw,
-                                   const AltChainParams& params) {
-  T t;
-  ValidationState state;
-  bool result = DeserializeFromVbkEncoding(raw, t, state, params);
   VBK_ASSERT_MSG(result, "Can't deserialize: %s", state.toString());
   return t;
 }

--- a/include/veriblock/pop/storage/adaptors/block_provider_impl.hpp
+++ b/include/veriblock/pop/storage/adaptors/block_provider_impl.hpp
@@ -71,9 +71,7 @@ template <typename BlockT>
 struct BlockIteratorImpl : public BlockIterator<BlockT> {
   ~BlockIteratorImpl() override = default;
 
-  BlockIteratorImpl(std::shared_ptr<StorageIterator> it,
-                    const AltChainParams& params)
-      : it_(it), params_(params) {}
+  BlockIteratorImpl(std::shared_ptr<StorageIterator> it) : it_(it) {}
 
   void next() override { it_->next(); }
 
@@ -82,8 +80,7 @@ struct BlockIteratorImpl : public BlockIterator<BlockT> {
     if (!it_->value(bytes)) {
       return false;
     }
-    out = AssertDeserializeFromVbkEncoding<StoredBlockIndex<BlockT>>(bytes,
-                                                                     params_);
+    out = AssertDeserializeFromVbkEncoding<StoredBlockIndex<BlockT>>(bytes);
     return true;
   }
 
@@ -112,14 +109,12 @@ struct BlockIteratorImpl : public BlockIterator<BlockT> {
 
  private:
   std::shared_ptr<StorageIterator> it_;
-  const AltChainParams& params_;
 };
 
 struct BlockReaderImpl : public BlockReader {
   ~BlockReaderImpl() override = default;
 
-  BlockReaderImpl(Storage& storage, const AltChainParams& params)
-      : storage_(storage), params_(params) {}
+  BlockReaderImpl(Storage& storage) : storage_(storage) {}
 
   bool getAltTip(AltBlock::hash_t& out) const override {
     std::vector<uint8_t> bytes_out;
@@ -164,17 +159,17 @@ struct BlockReaderImpl : public BlockReader {
   std::shared_ptr<BlockIterator<AltBlock>> getAltBlockIterator()
       const override {
     return std::make_shared<BlockIteratorImpl<AltBlock>>(
-        storage_.generateIterator(), params_);
+        storage_.generateIterator());
   }
   std::shared_ptr<BlockIterator<VbkBlock>> getVbkBlockIterator()
       const override {
     return std::make_shared<BlockIteratorImpl<VbkBlock>>(
-        storage_.generateIterator(), params_);
+        storage_.generateIterator());
   }
   std::shared_ptr<BlockIterator<BtcBlock>> getBtcBlockIterator()
       const override {
     return std::make_shared<BlockIteratorImpl<BtcBlock>>(
-        storage_.generateIterator(), params_);
+        storage_.generateIterator());
   }
 
  private:
@@ -192,13 +187,12 @@ struct BlockReaderImpl : public BlockReader {
       return false;
     }
 
-    out = AssertDeserializeFromVbkEncoding<StoredBlockIndex<block_t>>(bytes_out,
-                                                                      params_);
+    out =
+        AssertDeserializeFromVbkEncoding<StoredBlockIndex<block_t>>(bytes_out);
     return true;
   }
 
   Storage& storage_;
-  const AltChainParams& params_;
 };
 
 struct BlockBatchImpl : public BlockBatch {

--- a/include/veriblock/pop/storage/stored_block_index.hpp
+++ b/include/veriblock/pop/storage/stored_block_index.hpp
@@ -8,8 +8,6 @@
 
 namespace altintegration {
 
-struct AltChainParams;
-
 template <typename Block>
 struct StoredBlockIndex {
   using block_t = Block;
@@ -63,7 +61,6 @@ bool DeserializeFromVbkEncoding(
     ReadStream& stream,
     StoredBlockIndex<Block>& out,
     ValidationState& state,
-    const AltChainParams& params,
     typename Block::hash_t precalculatedHash = typename Block::hash_t()) {
   const auto& name = Block::name();
   using height_t = typename Block::height_t;
@@ -71,7 +68,7 @@ bool DeserializeFromVbkEncoding(
     return state.Invalid(name + "-stored-block-index-height");
   }
   Block block{};
-  if (!DeserializeFromRaw(stream, block, state, params, precalculatedHash)) {
+  if (!DeserializeFromRaw(stream, block, state, precalculatedHash)) {
     return state.Invalid(name + "-stored-block-index-header");
   }
   out.header = std::make_shared<Block>(block);

--- a/src/pop/blockchain/mempool_block_tree.cpp
+++ b/src/pop/blockchain/mempool_block_tree.cpp
@@ -67,7 +67,6 @@ bool MemPoolBlockTree::checkContextually(const ATV& atv,
 
   auto endorsed_hash =
       tree_->getParams().getHash(atv.transaction.publicationData.header);
-
   auto* endorsed_index = tree_->getBlockIndex(endorsed_hash);
   if (endorsed_index != nullptr) {
     auto* tip = tree_->getBestChain().tip();

--- a/src/pop/c/entities/altblock.cpp
+++ b/src/pop/c/entities/altblock.cpp
@@ -11,11 +11,10 @@
 #include <veriblock/pop/adaptors/picojson.hpp>
 // clang-format on
 
-#include "../config.hpp"
-#include "../validation_state.hpp"
 #include "altblock.hpp"
 #include "veriblock/pop/assert.hpp"
 #include "veriblock/pop/serde.hpp"
+#include "../validation_state.hpp"
 
 POP_ENTITY_FREE_SIGNATURE(alt_block) {
   if (self != nullptr) {
@@ -107,18 +106,14 @@ POP_ENTITY_SERIALIZE_TO_VBK(alt_block) {
   return res;
 }
 
-POP_ENTITY_DESERIALIZE_FROM_VBK(alt_block, POP_ENTITY_NAME(config) * config) {
+POP_ENTITY_DESERIALIZE_FROM_VBK(alt_block) {
   VBK_ASSERT(state);
-  VBK_ASSERT(config);
   VBK_ASSERT(bytes.data);
-  VBK_ASSERT(config->ref);
-  VBK_ASSERT(config->ref->alt);
 
   std::vector<uint8_t> v_bytes(bytes.data, bytes.data + bytes.size);
 
   altintegration::AltBlock out;
-  if (!altintegration::DeserializeFromVbkEncoding(
-          v_bytes, out, state->ref, *config->ref->alt)) {
+  if (!altintegration::DeserializeFromVbkEncoding(v_bytes, out, state->ref)) {
     return nullptr;
   }
 
@@ -137,10 +132,8 @@ namespace default_value {
 template <>
 altintegration::AltBlock generateDefaultValue<altintegration::AltBlock>() {
   altintegration::AltBlock res;
-  res.hash = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  res.previousBlock = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+  res.hash = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  res.previousBlock = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
   res.timestamp = 1;
   res.height = 1;
   return res;

--- a/src/pop/c/entities/btcblock.cpp
+++ b/src/pop/c/entities/btcblock.cpp
@@ -11,10 +11,9 @@
 #include <veriblock/pop/adaptors/picojson.hpp>
 // clang-format on
 
-#include "../config.hpp"
-#include "../validation_state.hpp"
 #include "btcblock.hpp"
 #include "veriblock/pop/assert.hpp"
+#include "../validation_state.hpp"
 #include "veriblock/pop/serde.hpp"
 
 POP_ENTITY_FREE_SIGNATURE(btc_block) {
@@ -121,18 +120,14 @@ POP_ENTITY_SERIALIZE_TO_VBK(btc_block) {
   return res;
 }
 
-POP_ENTITY_DESERIALIZE_FROM_VBK(btc_block, POP_ENTITY_NAME(config) * config) {
+POP_ENTITY_DESERIALIZE_FROM_VBK(btc_block) {
   VBK_ASSERT(state);
-  VBK_ASSERT(config);
   VBK_ASSERT(bytes.data);
-  VBK_ASSERT(config->ref);
-  VBK_ASSERT(config->ref->alt);
 
   std::vector<uint8_t> v_bytes(bytes.data, bytes.data + bytes.size);
 
   altintegration::BtcBlock out;
-  if (!altintegration::DeserializeFromVbkEncoding(
-          v_bytes, out, state->ref, *config->ref->alt)) {
+  if (!altintegration::DeserializeFromVbkEncoding(v_bytes, out, state->ref)) {
     return nullptr;
   }
 

--- a/src/pop/c/entities/vbkblock.cpp
+++ b/src/pop/c/entities/vbkblock.cpp
@@ -11,11 +11,10 @@
 #include <veriblock/pop/adaptors/picojson.hpp>
 // clang-format on
 
-#include "../config.hpp"
-#include "../validation_state.hpp"
 #include "vbkblock.hpp"
 #include "veriblock/pop/assert.hpp"
 #include "veriblock/pop/serde.hpp"
+#include "../validation_state.hpp"
 
 POP_ENTITY_FREE_SIGNATURE(vbk_block) {
   if (self != nullptr) {
@@ -168,18 +167,14 @@ POP_ENTITY_SERIALIZE_TO_VBK(vbk_block) {
   return res;
 }
 
-POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block, POP_ENTITY_NAME(config) * config) {
+POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block) {
   VBK_ASSERT(state);
-  VBK_ASSERT(config);
   VBK_ASSERT(bytes.data);
-  VBK_ASSERT(config->ref);
-  VBK_ASSERT(config->ref->alt);
 
   std::vector<uint8_t> v_bytes(bytes.data, bytes.data + bytes.size);
 
   altintegration::VbkBlock out;
-  if (!altintegration::DeserializeFromVbkEncoding(
-          v_bytes, out, state->ref, *config->ref->alt)) {
+  if (!altintegration::DeserializeFromVbkEncoding(v_bytes, out, state->ref)) {
     return nullptr;
   }
 

--- a/src/pop/c/pop_context.cpp
+++ b/src/pop/c/pop_context.cpp
@@ -44,7 +44,7 @@ POP_ENTITY_NEW_FUNCTION(pop_context,
       std::make_shared<altintegration::adaptors::PayloadsStorageImpl>(
           *storage->ref),
       std::make_shared<altintegration::adaptors::BlockReaderImpl>(
-          *storage->ref, *config->ref->alt));
+          *storage->ref));
 
   return res;
 }

--- a/src/pop/entities/altblock.cpp
+++ b/src/pop/entities/altblock.cpp
@@ -4,7 +4,6 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 #include <veriblock/pop/entities/altblock.hpp>
-#include <veriblock/pop/blockchain/alt_chain_params.hpp>
 #include <veriblock/pop/strutil.hpp>
 
 namespace altintegration {
@@ -53,28 +52,23 @@ void AltBlock::toVbkEncoding(WriteStream& stream) const {
 bool DeserializeFromVbkEncoding(ReadStream& stream,
                                 AltBlock& out,
                                 ValidationState& state,
-                                const AltChainParams& params,
                                 const AltBlock::hash_t& /* ignore */) {
-  return DeserializeFromRaw(stream, out, state, params);
+  return DeserializeFromRaw(stream, out, state);
 }
 
 bool DeserializeFromRaw(ReadStream& stream,
                         AltBlock& out,
                         ValidationState& state,
-                        const AltChainParams& params,
                         const AltBlock::hash_t& /* ignore */) {
-  if (!readSingleByteLenValue(stream,
-                              out.hash,
-                              state,
-                              params.mAltBlockHashSize,
-                              params.mAltBlockHashSize)) {
+  if (!readSingleByteLenValue(
+          stream, out.hash, state, MIN_ALT_HASH_SIZE, MAX_ALT_HASH_SIZE)) {
     return state.Invalid("alt-block-hash");
   }
   if (!readSingleByteLenValue(stream,
                               out.previousBlock,
                               state,
-                              params.mAltBlockHashSize,
-                              params.mAltBlockHashSize)) {
+                              MIN_ALT_HASH_SIZE,
+                              MAX_ALT_HASH_SIZE)) {
     return state.Invalid("alt-block-prevhash");
   }
   if (!stream.readBE<int32_t>(out.height, state)) {

--- a/src/pop/entities/btcblock.cpp
+++ b/src/pop/entities/btcblock.cpp
@@ -125,14 +125,6 @@ bool DeserializeFromRaw(ReadStream& stream,
   return true;
 }
 
-bool DeserializeFromRaw(ReadStream& stream,
-                        BtcBlock& block,
-                        ValidationState& state,
-                        const AltChainParams& /*ignore*/,
-                        const BtcBlock::hash_t& precalculatedHash) {
-  return DeserializeFromRaw(stream, block, state, precalculatedHash);
-}
-
 bool DeserializeFromVbkEncoding(ReadStream& stream,
                                 BtcBlock& out,
                                 ValidationState& state,
@@ -144,14 +136,6 @@ bool DeserializeFromVbkEncoding(ReadStream& stream,
   }
   out.hash_ = precalculatedHash;
   return DeserializeFromRaw(value, out, state);
-}
-
-bool DeserializeFromVbkEncoding(ReadStream& stream,
-                                BtcBlock& out,
-                                ValidationState& state,
-                                const AltChainParams& /*ignore*/,
-                                const BtcBlock::hash_t& precalculatedHash) {
-  return DeserializeFromVbkEncoding(stream, out, state, precalculatedHash);
 }
 
 BtcBlock::BtcBlock(uint32_t version,

--- a/src/pop/entities/vbkblock.cpp
+++ b/src/pop/entities/vbkblock.cpp
@@ -218,14 +218,6 @@ bool DeserializeFromRaw(ReadStream& stream,
   return true;
 }
 
-bool DeserializeFromRaw(ReadStream& stream,
-                        VbkBlock& block,
-                        ValidationState& state,
-                        const AltChainParams& /*ignore*/,
-                        const VbkBlock::hash_t& hash) {
-  return DeserializeFromRaw(stream, block, state, hash);
-}
-
 bool DeserializeFromVbkEncoding(ReadStream& stream,
                                 VbkBlock& out,
                                 ValidationState& state,
@@ -241,14 +233,6 @@ bool DeserializeFromVbkEncoding(ReadStream& stream,
 
   ReadStream s(value);
   return DeserializeFromRaw(s, out, state, precalculatedHash);
-}
-
-bool DeserializeFromVbkEncoding(ReadStream& stream,
-                                VbkBlock& out,
-                                ValidationState& state,
-                                const AltChainParams& /*ignore*/,
-                                const VbkBlock::hash_t& precalculatedHash) {
-  return DeserializeFromVbkEncoding(stream, out, state, precalculatedHash);
 }
 
 }  // namespace altintegration

--- a/src/pop/pop_context.cpp
+++ b/src/pop/pop_context.cpp
@@ -5,7 +5,7 @@ namespace altintegration {
 std::shared_ptr<PopContext> PopContext::create(
     std::shared_ptr<Config> config,
     std::shared_ptr<PayloadsStorage> payloadsProvider,
-    std::shared_ptr<BlockReader> blockProvider,
+    std::shared_ptr<BlockReader> blockProvider_,
     size_t validatorWorkers) {
   config->validate();
 
@@ -13,7 +13,7 @@ std::shared_ptr<PopContext> PopContext::create(
   auto ctx = std::shared_ptr<PopContext>(new PopContext());
   ctx->config_ = std::move(config);
   ctx->payloadsProvider_ = std::move(payloadsProvider);
-  ctx->blockProvider_ = std::move(blockProvider);
+  ctx->blockProvider_ = std::move(blockProvider_);
   ctx->altTree_ = std::make_shared<AltBlockTree>(*ctx->config_->alt,
                                                  *ctx->config_->vbk.params,
                                                  *ctx->config_->btc.params,

--- a/src/pop/storage/util.cpp
+++ b/src/pop/storage/util.cpp
@@ -141,10 +141,8 @@ bool loadTrees(AltBlockTree& tree, ValidationState& state) {
   }
   std::vector<typename AltBlockTree::stored_index_t> altblocks;
   typename AltBlock::hash_t alttip;
-  if (!detail::loadBlocksAndTip(altblocks,
-                                alttip,
-                                tree.getBlockProvider(),
-                                state)) {
+  if (!detail::loadBlocksAndTip(
+          altblocks, alttip, tree.getBlockProvider(), state)) {
     return state.Invalid("load-alt-tree-blocks");
   }
 

--- a/test/pop/alt-util_test.cpp
+++ b/test/pop/alt-util_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <util/alt_chain_params_regtest.hpp>
 #include <util/pop_test_fixture.hpp>
 #include <veriblock/pop/alt-util.hpp>
 #include <veriblock/pop/mock_miner.hpp>

--- a/test/pop/blockchain/alt_tree_bootstrap_test.cpp
+++ b/test/pop/blockchain/alt_tree_bootstrap_test.cpp
@@ -30,7 +30,7 @@ struct AltChainParamsNon0Bootstrap : public AltChainParams {
 
   std::vector<uint8_t> getHash(
       const std::vector<uint8_t>& bytes) const noexcept override {
-    return AssertDeserializeFromRaw<AltBlock>(bytes, *this).getHash();
+    return AssertDeserializeFromRaw<AltBlock>(bytes).getHash();
   }
 
   bool checkBlockHeader(const std::vector<uint8_t>&,
@@ -53,7 +53,7 @@ TEST_P(PositiveTest, BootstrapSuccess) {
   BtcChainParamsRegTest btc;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl pp{storage};
-  adaptors::BlockReaderImpl bp{storage, alt};
+  adaptors::BlockReaderImpl bp{storage};
 
   AltBlockTree tree(alt, vbk, btc, pp, bp);
   ValidationState state;
@@ -78,7 +78,7 @@ TEST_P(NegativeTest, BootstrapFail) {
   BtcChainParamsRegTest btc;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl pp{storage};
-  adaptors::BlockReaderImpl bp{storage, alt};
+  adaptors::BlockReaderImpl bp{storage};
 
   AltBlockTree tree(alt, vbk, btc, pp, bp);
   ValidationState state;
@@ -103,12 +103,11 @@ TEST_F(AltBlockTreeTest, AssureBootstrapBtcBlockHasRefs_test) {
   using vbk_block_tree = VbkBlockTree;
 
   ValidationState state;
-  AltChainParamsRegTest altparam;
   BtcChainParamsRegTest btc_params{};
   VbkChainParamsRegTest vbk_params{};
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloads_provider{storage};
-  adaptors::BlockReaderImpl block_provider{storage, altparam};
+  adaptors::BlockReaderImpl block_provider{storage};
   PayloadsIndex payloads_index;
 
   Miner<BtcBlock, BtcChainParams> btc_miner =

--- a/test/pop/blockchain/blockchain_test.cpp
+++ b/test/pop/blockchain/blockchain_test.cpp
@@ -44,10 +44,9 @@ struct BlockchainTest : public ::testing::Test {
 
   std::shared_ptr<BlockTree<block_t, params_base_t>> blockchain;
   std::shared_ptr<params_base_t> chainparam;
-  AltChainParamsRegTest altparam{};
   std::shared_ptr<Miner<block_t, params_base_t>> miner;
   adaptors::InmemStorageImpl storage{};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
 
   height_t height = 0;
   ValidationState state;

--- a/test/pop/blockchain/btc_blockchain_test.cpp
+++ b/test/pop/blockchain/btc_blockchain_test.cpp
@@ -26,10 +26,9 @@ struct BtcInvalidationTest {
   using hash_t = typename BlockTree<block_t, param_t>::hash_t;
 
   std::shared_ptr<param_t> params;
-  AltChainParamsRegTest altparam{};
   ValidationState state;
   adaptors::InmemStorageImpl storage{};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
 
   BtcInvalidationTest() { params = std::make_shared<BtcChainParamsRegTest>(); }
 };

--- a/test/pop/blockchain/pop/counting_context_test.cpp
+++ b/test/pop/blockchain/pop/counting_context_test.cpp
@@ -12,7 +12,7 @@
 using namespace altintegration;
 
 TEST(Counter, Amount) {
-  auto P = AltChainParamsRegTest();
+  auto P = AltChainParamsTest();
   P.mMaxATVsInAltBlock = 1;
   P.mMaxVTBsInAltBlock = 1;
   P.mMaxVbkBlocksInAltBlock = 1;
@@ -36,7 +36,7 @@ TEST(Counter, Amount) {
 }
 
 TEST(Counter, Size) {
-  auto P = AltChainParamsRegTest();
+  auto P = AltChainParamsTest();
   P.mMaxPopDataSize =
       (uint32_t)(PopData{}.estimateSize() + ATV{}.estimateSize());
   auto C = CountingContext(P);

--- a/test/pop/blockchain/pop/pop_context_test.cpp
+++ b/test/pop/blockchain/pop/pop_context_test.cpp
@@ -15,12 +15,11 @@
 using namespace altintegration;
 
 struct PopContextFixture : public ::testing::Test {
-  AltChainParamsRegTest altparam{};
   VbkChainParamsRegTest vbkp;
   BtcChainParamsRegTest btcp;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloadsProvider{storage};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
   PayloadsIndex payloadsIndex;
   VbkBlockTree local =
       VbkBlockTree(vbkp, btcp, payloadsProvider, blockProvider, payloadsIndex);

--- a/test/pop/blockchain/vbk_blockchain_test.cpp
+++ b/test/pop/blockchain/vbk_blockchain_test.cpp
@@ -26,12 +26,11 @@ struct BtcInvalidationTest {
 
   ValidationState state;
 
-  AltChainParamsRegTest altparam;
   BtcChainParamsRegTest btcparam;
   VbkChainParamsRegTest vbkparam;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloadsProvider{storage};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
   PayloadsIndex payloadsIndex;
 };
 
@@ -312,12 +311,11 @@ TEST(VbkBlocksTest, basic_test1) {
 
   };
 
-  AltChainParamsRegTest altparam;
   VbkChainParamsTest vbkparam;
   BtcChainParamsRegTest btcparam;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloadsProvider{storage};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
   PayloadsIndex payloadsIndex;
   ValidationState state;
 
@@ -587,12 +585,11 @@ TEST(VbkBlocksTest, basic_test2) {
       "741CB53B2D65BE9E963E7573730218626035494E040C45720001EBD567",
   };
 
-  AltChainParamsRegTest altparam;
   VbkChainParamsTest vbkparam;
   BtcChainParamsRegTest btcparam;
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloadsProvider{storage};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
   PayloadsIndex payloadsIndex;
   ValidationState state;
 

--- a/test/pop/blockchain/vbk_blockchain_util_test.cpp
+++ b/test/pop/blockchain/vbk_blockchain_util_test.cpp
@@ -312,10 +312,9 @@ struct BlockchainTest : public ::testing::Test {
 
   std::shared_ptr<BlockTree<block_t, params_base_t>> blockchain;
   std::shared_ptr<params_base_t> chainparam;
-  AltChainParamsRegTest altparam;
   std::shared_ptr<Miner<block_t, params_base_t>> miner;
   adaptors::InmemStorageImpl storage{};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
   ValidationState state;
 
   BlockchainTest() {

--- a/test/pop/blockchain/vbk_getblockproof_test.cpp
+++ b/test/pop/blockchain/vbk_getblockproof_test.cpp
@@ -25,10 +25,9 @@ struct GetProofTest : public testing::Test {
   using hash_t = typename BlockTree<block_t, param_t>::hash_t;
 
   std::shared_ptr<param_t> params;
-  AltChainParamsRegTest altparam;
   ValidationState state;
   adaptors::InmemStorageImpl storage{};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
 
   std::vector<VbkBlock> allBlocks{};
   std::vector<ArithUint256> cumulativeDifficulties{};

--- a/test/pop/crypto/progpow_cache_test.cpp
+++ b/test/pop/crypto/progpow_cache_test.cpp
@@ -6,9 +6,9 @@
 #include <gtest/gtest.h>
 
 #include <veriblock/pop/entities/vbkblock.hpp>
-#include <veriblock/pop/blockchain/alt_chain_params.hpp>
 #include <veriblock/pop/blockchain/vbk_chain_params.hpp>
 #include <veriblock/pop/blockchain/btc_chain_params.hpp>
+#include "util/alt_chain_params_regtest.hpp"
 #include <veriblock/pop/crypto/progpow.hpp>
 
 using namespace altintegration;

--- a/test/pop/entities/altblock_test.cpp
+++ b/test/pop/entities/altblock_test.cpp
@@ -4,7 +4,6 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 #include <veriblock/pop/entities/altblock.hpp>
-#include <veriblock/pop/blockchain/alt_chain_params.hpp>
 
 #include <gtest/gtest.h>
 
@@ -19,9 +18,8 @@ static const AltBlock defaultBlock{
     1466};
 
 TEST(AltBlock, RoundTrip) {
-  AltChainParamsRegTest altparam{};
   std::vector<uint8_t> bytes = defaultBlock.toRaw();
-  AltBlock deserializedBlock = AssertDeserializeFromRaw<AltBlock>(bytes, altparam);
+  AltBlock deserializedBlock = AssertDeserializeFromRaw<AltBlock>(bytes);
 
   EXPECT_EQ(deserializedBlock.getHash(), defaultBlock.getHash());
   EXPECT_EQ(deserializedBlock.height, defaultBlock.height);

--- a/test/pop/entities/blockindex_test.cpp
+++ b/test/pop/entities/blockindex_test.cpp
@@ -14,16 +14,13 @@
 #include <veriblock/pop/serde.hpp>
 #include <veriblock/pop/storage/stored_block_index.hpp>
 
-#include <veriblock/pop/literals.hpp>
-
 static const std::string AltBlockIndexVbkEncoded =
-    "00000000201fec8aa4983d69395010e4d18cd8b943749d5b4f575e88a375debdc5ed22531c"
-    "201aaaaaaaaaaaa9395010e4d18cd8b943749d5b4f575e88a375debdc5ed22531c000005ba"
-    "0000009c000000000100010220010000000000000000000000000000000000000000000000"
-    "00000000000000002002000000000000000000000000000000000000000000000000000000"
-    "00000000010220030000000000000000000000000000000000000000000000000000000000"
-    "00002004000000000000000000000000000000000000000000000000000000000000000102"
-    "0c0500000000000000000000000c0600000000000000000000000100";
+    "000031c70cfbe6c1cd7ceb5e36cba675560c76bc289cc7a324cff40777980000406d000022"
+    "960000000601000102200192219fd88238e59cb1760dc881461c5cc5be252dc98b6e7f942c"
+    "ced5695f59200894d94097633af23e724087ca2b3b5f2b8ec106cb2ea25b1e7c1ef27b4856"
+    "b6010220a3415c17f0bc012706e77b07ba0e760729b10048038886da2ac5ff217c99677d20"
+    "ecf96f29d8a27364975baccf517aa71713a9f5d322ea25b090d9efcb0e31b25e01020c2a85"
+    "01d3be4d60d3a42574060cfd816e28a98b673ea42051c10100";
 
 static const std::string VbkBlockIndexVbkEncoded =
     "0000339d00000000124b3f9c46bbefc75421502bd0ef5af409cf5f359194367f897099b11e"
@@ -38,37 +35,28 @@ static const std::string BtcBlockIndexVbkEncoded =
 
 using namespace altintegration;
 
-static const AltBlock defaultBlock{
-    "1fec8aa4983d69395010e4d18cd8b943749d5b4f575e88a375debdc5ed22531c"_unhex,
-    "1aaaaaaaaaaaa9395010e4d18cd8b943749d5b4f575e88a375debdc5ed22531c"_unhex,
-    156,
-    1466};
-
 TEST(BlockIndex, BTC) {
-  AltChainParamsRegTest altparam{};
   StoredBlockIndex<BtcBlock> index;
   auto data = ParseHex(BtcBlockIndexVbkEncoded);
   ReadStream stream(data);
   ValidationState state;
-  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state, altparam));
+  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state));
 }
 
 TEST(BlockIndex, VBK) {
-  AltChainParamsRegTest altparam{};
   StoredBlockIndex<VbkBlock> index;
   auto data = ParseHex(VbkBlockIndexVbkEncoded);
   ReadStream stream(data);
   ValidationState state;
-  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state, altparam));
+  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state));
 }
 
 TEST(BlockIndex, ALT) {
-  AltChainParamsRegTest altparam{};
   StoredBlockIndex<AltBlock> index;
   auto data = ParseHex(AltBlockIndexVbkEncoded);
   ReadStream stream(data);
   ValidationState state;
-  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state, altparam))
+  ASSERT_TRUE(DeserializeFromVbkEncoding(stream, index, state))
       << state.toString();
 }
 
@@ -82,12 +70,10 @@ TYPED_TEST_P(BlockIndexTest, RoundTrip) {
   using Index = StoredBlockIndex<Block>;
   Index index = getRandomIndex<Block>();
   ValidationState state;
-  AltChainParamsRegTest altparam{};
 
   auto vbkencoded = SerializeToVbkEncoding<Index>(index);
   Index decodedVbk;
-  ASSERT_TRUE(
-      DeserializeFromVbkEncoding<Index>(vbkencoded, decodedVbk, state, altparam))
+  ASSERT_TRUE(DeserializeFromVbkEncoding<Index>(vbkencoded, decodedVbk, state))
       << state.toString();
   ASSERT_TRUE(state.IsValid());
   ASSERT_EQ(index.toVbkEncoding(), decodedVbk.toVbkEncoding());
@@ -108,9 +94,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(BlockIndexTestSuite,
                                TypesUnderTest);
 
 TEST(AltBlockIndex, IdsAreEqual) {
-  AltChainParamsRegTest altparam{};
   StoredBlockIndex<AltBlock> index;
-  index.header = std::make_shared<AltBlock>(defaultBlock);
   index.addon._atvids.push_back(uint256::fromHex("01"));
   index.addon._atvids.push_back(uint256::fromHex("02"));
   index.addon._vtbids.push_back(uint256::fromHex("03"));
@@ -122,14 +106,13 @@ TEST(AltBlockIndex, IdsAreEqual) {
   StoredBlockIndex<AltBlock> after;
   auto hex = SerializeToHex(index);
 
-  ASSERT_TRUE(DeserializeFromHex(hex, after, state, altparam));
+  ASSERT_TRUE(DeserializeFromHex(hex, after, state));
   ASSERT_EQ(index.addon._atvids, after.addon._atvids);
   ASSERT_EQ(index.addon._vtbids, after.addon._vtbids);
   ASSERT_EQ(index.addon._vbkblockids, after.addon._vbkblockids);
 }
 
 TEST(VbkBlockIndex, IdsAreEqual) {
-  AltChainParamsRegTest altparam{};
   StoredBlockIndex<VbkBlock> index;
   index.addon._vtbids.push_back(uint256::fromHex("01"));
   index.addon._vtbids.push_back(uint256::fromHex("02"));
@@ -138,6 +121,6 @@ TEST(VbkBlockIndex, IdsAreEqual) {
   StoredBlockIndex<VbkBlock> after;
   auto hex = SerializeToHex(index);
 
-  ASSERT_TRUE(DeserializeFromHex(hex, after, state, altparam));
+  ASSERT_TRUE(DeserializeFromHex(hex, after, state));
   ASSERT_EQ(index.addon._vtbids, after.addon._vtbids);
 }

--- a/test/pop/entities/json_test.cpp
+++ b/test/pop/entities/json_test.cpp
@@ -693,9 +693,9 @@ TEST(ToJson, AltParams) {
 
   std::string expected = R"({
   "bootstrapBlock": {
-    "hash": "0101010101010101010101010101010101010101010101010101010101010101",
+    "hash": "010101010101010101010101",
     "height": 0,
-    "previousBlock": "0000000000000000000000000000000000000000000000000000000000000000",
+    "previousBlock": "000000000000000000000000",
     "timestamp": 0
   },
   "endorsementSettlementInterval": 50,

--- a/test/pop/mempool_test.cpp
+++ b/test/pop/mempool_test.cpp
@@ -829,9 +829,7 @@ TEST_F(MemPoolFixture, getPop_scenario_13) {
   auto* containigBlock = popminer->mineVbkBlocks(1, txs);
   for (const auto& tx : txs) {
     ATV atv = popminer->createATV(containigBlock->getHeader(), tx);
-    auto res = mempool->submit(atv, state);
-    EXPECT_FALSE(res.isAccepted()) << state.toString();
-    state.reset();
+    submitATV(atv);
   }
 
   // mine 5 VBK blocks

--- a/test/pop/stateless_validation_test.cpp
+++ b/test/pop/stateless_validation_test.cpp
@@ -5,7 +5,6 @@
 
 #include <gtest/gtest.h>
 
-#include <veriblock/pop/blockchain/alt_chain_params.hpp>
 #include <veriblock/pop/blockchain/btc_chain_params.hpp>
 #include <veriblock/pop/blockchain/vbk_chain_params.hpp>
 #include <veriblock/pop/crypto/progpow.hpp>
@@ -13,6 +12,7 @@
 #include <veriblock/pop/pop_stateless_validator.hpp>
 #include <veriblock/pop/stateless_validation.hpp>
 
+#include "util/alt_chain_params_regtest.hpp"
 #include "util/pop_test_fixture.hpp"
 #include "util/test_utils.hpp"
 

--- a/test/pop/util/alt_chain_params_regtest.hpp
+++ b/test/pop/util/alt_chain_params_regtest.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2021 Xenios SEZC
+// https://www.veriblock.org
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ALTINTEGRATION_ALT_CHAIN_PARAMS_REGTEST_HPP
+#define ALTINTEGRATION_ALT_CHAIN_PARAMS_REGTEST_HPP
+
+#include <veriblock/pop/blockchain/alt_chain_params.hpp>
+
+namespace altintegration {
+
+struct AltChainParamsRegTest : public AltChainParams {
+  AltChainParamsRegTest(int id = 0) : id(id) {}
+  ~AltChainParamsRegTest() override = default;
+
+  AltBlock getBootstrapBlock() const noexcept override {
+    AltBlock b;
+    b.hash = std::vector<uint8_t>(12, 1);
+    b.previousBlock = std::vector<uint8_t>(12, 0);
+    b.height = 0;
+    b.timestamp = 0;
+    return b;
+  }
+
+  int64_t getIdentifier() const noexcept override { return id; }
+
+  std::vector<uint8_t> getHash(
+      const std::vector<uint8_t>& bytes) const noexcept override {
+    return AssertDeserializeFromRaw<AltBlock>(bytes).getHash();
+  }
+
+  bool checkBlockHeader(const std::vector<uint8_t>&,
+                        const std::vector<uint8_t>&,
+                        ValidationState&) const noexcept override {
+    return true;
+  }
+
+  int64_t id = 0;
+};
+
+}  // namespace altintegration
+
+#endif  // ALTINTEGRATION_ALT_CHAIN_PARAMS_REGTEST_HPP

--- a/test/pop/util/pop_test_fixture.hpp
+++ b/test/pop/util/pop_test_fixture.hpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <util/alt_chain_params_regtest.hpp>
 #include <util/test_utils.hpp>
 #include <veriblock/pop/alt-util.hpp>
 #include <veriblock/pop/blockchain/alt_block_tree.hpp>
@@ -43,7 +44,7 @@ struct PopTestFixture {
   AltChainParamsRegTest altparam{};
   adaptors::InmemStorageImpl storage{};
   adaptors::PayloadsStorageImpl payloadsProvider{storage};
-  adaptors::BlockReaderImpl blockProvider{storage, altparam};
+  adaptors::BlockReaderImpl blockProvider{storage};
 
   // miners
   std::shared_ptr<MockMiner> popminer;

--- a/test/pop/util/test_utils.hpp
+++ b/test/pop/util/test_utils.hpp
@@ -146,8 +146,8 @@ inline StoredBlockIndex<AltBlock> getRandomIndex() {
   index.height = rand();
 
   AltBlock block;
-  block.hash = generateRandomBytesVector(32);
-  block.previousBlock = generateRandomBytesVector(32);
+  block.hash = generateRandomBytesVector(12);
+  block.previousBlock = generateRandomBytesVector(12);
   block.timestamp = rand();
   block.height = rand();
 
@@ -164,6 +164,30 @@ inline StoredBlockIndex<AltBlock> getRandomIndex() {
 
   return index;
 }
+
+struct AltChainParamsTest : public AltChainParams {
+  AltBlock getBootstrapBlock() const noexcept override {
+    AltBlock genesisBlock;
+    genesisBlock.hash = std::vector<uint8_t>(10, 1);
+    genesisBlock.previousBlock = std::vector<uint8_t>(10, 2);
+    genesisBlock.height = 0;
+    genesisBlock.timestamp = 0;
+    return genesisBlock;
+  }
+
+  int64_t getIdentifier() const noexcept override { return 0x7ec7; }
+
+  std::vector<uint8_t> getHash(
+      const std::vector<uint8_t>& bytes) const noexcept override {
+    return AssertDeserializeFromRaw<AltBlock>(bytes).getHash();
+  }
+
+  bool checkBlockHeader(const std::vector<uint8_t>&,
+                        const std::vector<uint8_t>&,
+                        ValidationState&) const noexcept override {
+    return true;
+  }
+};
 
 }  // namespace altintegration
 


### PR DESCRIPTION
Reverts VeriBlock/alt-integration-cpp#878

This adds issue on mainnet:
2021-10-26T18:40:49Z ERROR: loadTrees: failed to load trees load-alt-tree-blocks+bad-value, Can not read block data

I think because "checkBlockHeader" function parses ALT BLOCK instead of actual block header.