### PR TITLE
add and use BlockIndex::isRoot(); replace genesis->root, as the block tree root is usually not a genesis block due to finalization

### DIFF
--- a/include/veriblock/pop/blockchain/blocktree.hpp
+++ b/include/veriblock/pop/blockchain/blocktree.hpp
@@ -141,17 +141,17 @@ struct BlockTree : public BaseBlockTree<Block> {
     auto* current = base::getBlockIndex(hash);
     VBK_ASSERT(current);
 
-    auto* prev = current->pprev;
     // we only check blocks contextually if they are not bootstrap blocks, and
     // previous block exists
-    if (prev && !current->hasFlags(BLOCK_BOOTSTRAP) &&
-        !contextuallyCheckBlock(*prev, current->getHeader(), state, *param_)) {
+    if (!current->isRoot() && !current->hasFlags(BLOCK_BOOTSTRAP) &&
+        !contextuallyCheckBlock(
+            *current->pprev, current->getHeader(), state, *param_)) {
       return state.Invalid("bad-block-contextually");
     }
 
     // recover chainwork
     current->chainWork = getBlockProof(current->getHeader());
-    if (prev) {
+    if (!current->isRoot()) {
       current->chainWork += current->pprev->chainWork;
     }
 
@@ -347,7 +347,7 @@ struct BlockTree : public BaseBlockTree<Block> {
   //! whenever new block is inserted, BlockTree has to update its ChainWork
   void onBlockInserted(index_t* newIndex) override final {
     newIndex->chainWork = getBlockProof(newIndex->getHeader());
-    if (newIndex->pprev) {
+    if (!newIndex->isRoot()) {
       newIndex->chainWork += newIndex->pprev->chainWork;
     }
   }

--- a/include/veriblock/pop/blockchain/pop/pop_state_machine.hpp
+++ b/include/veriblock/pop/blockchain/pop/pop_state_machine.hpp
@@ -20,7 +20,7 @@ namespace {
 
 template <typename index_t>
 void assertBlockCanBeApplied(index_t& index) {
-  VBK_ASSERT(index.pprev && "cannot apply the genesis block");
+  VBK_ASSERT_MSG(!index.isRoot(), "cannot apply the root block");
 
   VBK_ASSERT_MSG(index.pprev->hasFlags(BLOCK_ACTIVE),
                  "state corruption: tried to apply a block that follows an "
@@ -44,7 +44,7 @@ void assertBlockCanBeApplied(index_t& index) {
 
 template <typename index_t>
 void assertBlockCanBeUnapplied(index_t& index) {
-  VBK_ASSERT(index.pprev && "cannot unapply the genesis block");
+  VBK_ASSERT_MSG(!index.isRoot(), "cannot unapply the root block");
 
   VBK_ASSERT_MSG(
       index.hasFlags(BLOCK_ACTIVE),

--- a/include/veriblock/pop/blockchain/temp_block_tree.hpp
+++ b/include/veriblock/pop/blockchain/temp_block_tree.hpp
@@ -147,11 +147,10 @@ struct TempBlockTree {
     current->setHeader(std::move(header));
     current->pprev = prev;
 
-    if (current->pprev != nullptr) {
-      // prev block found
-      current->setHeight(current->pprev->getHeight() + 1);
-    } else {
+    if (current->isRoot()) {
       current->setHeight(0);
+    } else {
+      current->setHeight(current->pprev->getHeight() + 1);
     }
 
     return current;

--- a/src/pop/blockchain/alt_block_tree.cpp
+++ b/src/pop/blockchain/alt_block_tree.cpp
@@ -161,8 +161,8 @@ void AltBlockTree::setPayloads(index_t& index, const PopData& payloads) {
                  "state corruption: block %s is applied",
                  index.toPrettyString());
 
-  VBK_ASSERT_MSG(index.pprev,
-                 "Adding payloads to a bootstrap block is not allowed");
+  VBK_ASSERT_MSG(!index.isRoot(),
+                 "Adding payloads to the root block is not allowed");
 
   ValidationState state;
   VBK_ASSERT_MSG(
@@ -400,7 +400,8 @@ void AltBlockTree::removeAllPayloads(index_t& index) {
                 index.toShortPrettyString());
 
   // we do not allow adding payloads to the genesis block
-  VBK_ASSERT_MSG(index.pprev, "can not remove payloads from the genesis block");
+  VBK_ASSERT_MSG(!index.isRoot(),
+                 "can not remove payloads from the root block");
   VBK_ASSERT_MSG(index.hasFlags(BLOCK_HAS_PAYLOADS),
                  "Can remove payloads only from blocks with payloads");
   VBK_ASSERT_MSG(!index.hasFlags(BLOCK_ACTIVE), "block is applied");
@@ -448,8 +449,8 @@ AltBlockTree::BlockPayloadMutator::BlockPayloadMutator(tree_t& tree,
       payload_index_(tree.getPayloadsIndex()),
       // don't look for duplicates in the block itself
       chain_(tree.getParams().getBootstrapBlock().height, block_.pprev) {
-  VBK_ASSERT_MSG(block_.pprev,
-                 "Adding payloads to a bootstrap block is not allowed");
+  VBK_ASSERT_MSG(!block_.isRoot(),
+                 "Adding payloads to the root block is not allowed");
   VBK_ASSERT_MSG(block_.isValidUpTo(BLOCK_VALID_TREE),
                  "block %s should be valid",
                  block_.toPrettyString());
@@ -634,7 +635,7 @@ bool AltBlockTree::loadBlockInner(const stored_index_t& index,
   if (!checkIdsForDuplicates<VTB>(vtbIds, state)) return false;
   if (!checkIdsForDuplicates<ATV>(atvIds, state)) return false;
 
-  if (current->pprev != nullptr) {
+  if (!current->isRoot()) {
     // if the block is not yet connected, defer the stateful duplicate check to
     // connectBlock()
     if (current->isConnected()) {

--- a/src/pop/blockchain/pop/vbk_block_tree.cpp
+++ b/src/pop/blockchain/pop/vbk_block_tree.cpp
@@ -95,8 +95,9 @@ void VbkBlockTree::removePayloads(index_t& index,
   VBK_LOG_DEBUG(
       "remove %d payloads from %s", pids.size(), index.toPrettyString());
 
-  // we do not allow adding payloads to the genesis block
-  VBK_ASSERT(index.pprev && "can not remove payloads from the genesis block");
+  // we do not allow adding payloads to the root block
+  VBK_ASSERT_MSG(!index.isRoot(),
+                 "can not remove payloads from the root block");
 
   if (pids.empty()) {
     return;


### PR DESCRIPTION
… 