### PR TITLE
Revert "make ATV and VTB go bindings to match the Payload interface"

### DIFF
--- a/bindings/go/api/ffi.go
+++ b/bindings/go/api/ffi.go
@@ -10,5 +10,5 @@ type Payload interface {
 	GetID() []byte
 	ToJSON() (map[string]interface{}, error)
 	SerializeToVbk() []byte
-	DeserializeFromVbk(bytes []byte) error
+	DeserializeFromVbk(data []byte) error
 }

--- a/bindings/go/api/serde_test.go
+++ b/bindings/go/api/serde_test.go
@@ -65,7 +65,7 @@ func TestVbkBlockSerde(t *testing.T) {
 	encodedBytes := assertHexDecode(defaultVbkBlockEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(encodedBytes)
+	err := vbkBlock.DeserializeFromVbk(encodedBytes, config)
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -81,7 +81,7 @@ func TestVbkBlockSerde(t *testing.T) {
 
 	assert.Equal(vbkBlock.SerializeToVbk(), encodedBytes)
 
-	err = vbkBlock.DeserializeFromVbk([]byte{1, 2, 3, 4})
+	err = vbkBlock.DeserializeFromVbk([]byte{1, 2, 3, 4}, config)
 	assert.Error(err)
 }
 
@@ -122,7 +122,7 @@ func TestVtbSerde(t *testing.T) {
 	encodedBytes := assertHexDecode(defaultVtbEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
+	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -149,7 +149,7 @@ func TestAtvSerde(t *testing.T) {
 	encodedBytes := assertHexDecode(defaultAtvEncoded)
 
 	vbkBlock := CreateVbkBlock()
-	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
+	err := vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 
@@ -203,7 +203,7 @@ func TestPopDataSerde(t *testing.T) {
 	assert.NotNil(vtb)
 
 	vbkBlock := CreateVbkBlock()
-	err = vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded))
+	err = vbkBlock.DeserializeFromVbk(assertHexDecode(defaultVbkBlockEncoded), config)
 	assert.NoError(err)
 	assert.NotNil(vbkBlock)
 

--- a/bindings/go/api/vbkblock.go
+++ b/bindings/go/api/vbkblock.go
@@ -155,11 +155,11 @@ func (v *VbkBlock) SerializeToVbk() []byte {
 	return createBytes(&res)
 }
 
-func (v *VbkBlock) DeserializeFromVbk(bytes []byte) error {
+func (v *VbkBlock) DeserializeFromVbk(bytes []byte, config *Config) error {
 	state := NewValidationState()
 	defer state.Free()
 
-	res := C.pop_vbk_block_deserialize_from_vbk(createCBytes(bytes), state.ref)
+	res := C.pop_vbk_block_deserialize_from_vbk(createCBytes(bytes), state.ref, config.ref)
 	if res == nil {
 		return state.Error()
 	}

--- a/include/veriblock/pop/c/entities/vbkblock.h
+++ b/include/veriblock/pop/c/entities/vbkblock.h
@@ -35,7 +35,7 @@ POP_ENTITY_GETTER_FUNCTION(vbk_block, int32_t, height);
 POP_ENTITY_TO_JSON(vbk_block);
 
 POP_ENTITY_SERIALIZE_TO_VBK(vbk_block);
-POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block);
+POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block, POP_ENTITY_NAME(config) *);
 
 POP_DECLARE_ARRAY(POP_ENTITY_NAME(vbk_block) *, vbk_block);
 

--- a/src/pop/c/entities/vbkblock.cpp
+++ b/src/pop/c/entities/vbkblock.cpp
@@ -168,21 +168,20 @@ POP_ENTITY_SERIALIZE_TO_VBK(vbk_block) {
   return res;
 }
 
-POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block) {
+POP_ENTITY_DESERIALIZE_FROM_VBK(vbk_block, POP_ENTITY_NAME(config) * config) {
   VBK_ASSERT(state);
+  VBK_ASSERT(config);
   VBK_ASSERT(bytes.data);
-
-  auto config = pop_config_new();
+  VBK_ASSERT(config->ref);
+  VBK_ASSERT(config->ref->alt);
 
   std::vector<uint8_t> v_bytes(bytes.data, bytes.data + bytes.size);
 
   altintegration::VbkBlock out;
   if (!altintegration::DeserializeFromVbkEncoding(
           v_bytes, out, state->ref, *config->ref->alt)) {
-    pop_config_free(config);
     return nullptr;
   }
-  pop_config_free(config);
 
   auto* res = new POP_ENTITY_NAME(vbk_block);
   res->ref = std::move(out);


### PR DESCRIPTION
Reverts VeriBlock/alt-integration-cpp#917